### PR TITLE
Add configurable lock filename.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ dependencies are the same as in the _dependencies-lock.json_ file.
       <groupId>se.vandmo</groupId>
       <artifactId>dependency-lock-maven-plugin</artifactId>
       <version>use latest version</version>
+      <configuration>
+        <filename>optional-lock-filename.json</filename>
+      </configuration>
       <executions>
         <execution>
           <id>check</id>

--- a/src/main/java/se/vandmo/dependencylock/maven/CheckMojo.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/CheckMojo.java
@@ -30,9 +30,12 @@ public final class CheckMojo extends AbstractMojo {
     readonly = true)
   private MavenProject project;
 
+  @Parameter(defaultValue = DependenciesLockFile.DEFAULT_FILENAME)
+  private String filename;
+
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
-    DependenciesLockFile lockFile = DependenciesLockFile.fromBasedir(basedir);
+    DependenciesLockFile lockFile = DependenciesLockFile.fromBasedir(basedir, filename);
     if (!lockFile.exists()) {
       getLog().error("No lock file found, create one by running 'mvn se.vandmo:dependency-lock-maven-plugin:lock'");
       return;

--- a/src/main/java/se/vandmo/dependencylock/maven/DependenciesLockFile.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/DependenciesLockFile.java
@@ -11,14 +11,16 @@ import java.io.File;
 
 public final class DependenciesLockFile {
 
+  public static final String DEFAULT_FILENAME = "dependencies-lock.json";
+
   private final File file;
 
   private DependenciesLockFile(File file) {
     this.file = file;
   }
 
-  public static DependenciesLockFile fromBasedir(File basedir) {
-    return new DependenciesLockFile(new File(basedir, "dependencies-lock.json"));
+  public static DependenciesLockFile fromBasedir(File basedir, String filename) {
+    return new DependenciesLockFile(new File(basedir, filename));
   }
 
   public LockedDependencies read() {

--- a/src/main/java/se/vandmo/dependencylock/maven/FormatMojo.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/FormatMojo.java
@@ -20,9 +20,12 @@ public final class FormatMojo extends AbstractMojo {
     readonly = true)
   private File basedir;
 
+  @Parameter(defaultValue = DependenciesLockFile.DEFAULT_FILENAME)
+  private String filename;
+
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
-    DependenciesLockFile.fromBasedir(basedir).format();
+    DependenciesLockFile.fromBasedir(basedir, filename).format();
   }
 
 }

--- a/src/main/java/se/vandmo/dependencylock/maven/LockMojo.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/LockMojo.java
@@ -28,9 +28,12 @@ public final class LockMojo extends AbstractMojo {
     readonly = true)
   private MavenProject project;
 
+  @Parameter(defaultValue = DependenciesLockFile.DEFAULT_FILENAME)
+  private String filename;
+
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
-    DependenciesLockFile lockFile = DependenciesLockFile.fromBasedir(basedir);
+    DependenciesLockFile lockFile = DependenciesLockFile.fromBasedir(basedir, filename);
     LockedDependencies existingLockedDependencies = getExistingLockedDependencies(lockFile);
     LockedDependencies lockedDependencies = existingLockedDependencies.updateWith(Artifacts.from(project.getArtifacts()));
     lockFile.write(lockedDependencies);


### PR DESCRIPTION
Allow builds that use profiles to control dependencies to specify a different lock file per profile. Default behaviour is unchanged.

Allows for configuration block like:
```
<configuration>
  <filename>optional-lock-filename.json</filename>
</configuration>
```