### PR TITLE
Add the artifact type to the ArtifactIdentifier.

### DIFF
--- a/src/main/java/se/vandmo/dependencylock/maven/Artifact.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/Artifact.java
@@ -17,7 +17,8 @@ public final class Artifact implements Comparable<Artifact> {
         new ArtifactIdentifier(
             artifact.getGroupId(),
             artifact.getArtifactId(),
-            ofNullable(artifact.getClassifier())),
+            ofNullable(artifact.getClassifier()),
+            ofNullable(artifact.getType())),
         artifact.getVersion(),
         artifact.getScope(),
         artifact.getType());

--- a/src/main/java/se/vandmo/dependencylock/maven/ArtifactIdentifier.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/ArtifactIdentifier.java
@@ -11,21 +11,25 @@ public final class ArtifactIdentifier implements Comparable<ArtifactIdentifier> 
   public final String groupId;
   public final String artifactId;
   public final Optional<String> classifier;
+  public final Optional<String> type;
 
   public static ArtifactIdentifier from(org.apache.maven.artifact.Artifact artifact) {
     return new ArtifactIdentifier(
         artifact.getGroupId(),
         artifact.getArtifactId(),
-        ofNullable(artifact.getClassifier()));
+        ofNullable(artifact.getClassifier()),
+        ofNullable(artifact.getType()));
   }
 
   ArtifactIdentifier(
       String groupId,
       String artifactId,
-      Optional<String> classifier) {
+      Optional<String> classifier,
+      Optional<String> type) {
     this.groupId = requireNonNull(groupId);
     this.artifactId = requireNonNull(artifactId);
     this.classifier = requireNonNull(classifier);
+    this.type = requireNonNull(type);
   }
 
   @Override
@@ -42,6 +46,9 @@ public final class ArtifactIdentifier implements Comparable<ArtifactIdentifier> 
     classifier.ifPresent(actualClassifier -> {
       sb.append(':').append(actualClassifier);
     });
+    type.ifPresent(actualType -> {
+      sb.append(':').append(actualType);
+    });
     return sb.toString();
   }
 
@@ -51,6 +58,7 @@ public final class ArtifactIdentifier implements Comparable<ArtifactIdentifier> 
     hash = 17 * hash + Objects.hashCode(this.groupId);
     hash = 17 * hash + Objects.hashCode(this.artifactId);
     hash = 17 * hash + Objects.hashCode(this.classifier);
+    hash = 17 * hash + Objects.hashCode(this.type);
     return hash;
   }
 
@@ -73,6 +81,9 @@ public final class ArtifactIdentifier implements Comparable<ArtifactIdentifier> 
       return false;
     }
     if (!Objects.equals(this.classifier, other.classifier)) {
+      return false;
+    }
+    if (!Objects.equals(this.type, other.type)) {
       return false;
     }
     return true;

--- a/src/main/java/se/vandmo/dependencylock/maven/LockedDependency.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/LockedDependency.java
@@ -32,7 +32,8 @@ public final class LockedDependency implements Comparable<LockedDependency> {
         new ArtifactIdentifier(
             getStringValue(json, "groupId"),
             getStringValue(json, "artifactId"),
-            possiblyGetStringValue(json, "classifier")),
+            possiblyGetStringValue(json, "classifier"),
+            possiblyGetStringValue(json, "type")),
         LockedVersion.fromJson(json.get("version")),
         getStringValue(json, "scope"),
         getStringValue(json, "type"));


### PR DESCRIPTION
This avoids a failure in the 'check' phase when the same artifact is added
but with a different type.