### PR TITLE
Update error message if no lock file is present

### DIFF
--- a/src/main/java/se/vandmo/dependencylock/maven/CheckMojo.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/CheckMojo.java
@@ -43,7 +43,7 @@ public final class CheckMojo extends AbstractMojo {
     DependenciesLockFile lockFile = DependenciesLockFile.fromBasedir(basedir, filename);
     if (!lockFile.exists()) {
       throw new MojoExecutionException(
-          "No lock file found, create one by running 'mvn se.vandmo:dependency-lock-maven-plugin:lock'");
+          "No lock file found, create one by running 'mvn se.vandmo:dependency-lock-maven-plugin:create-lock-file'");
     }
     ArtifactFilter useMyVersionForFilter = new StrictPatternIncludesArtifactFilter(asList(useMyVersionFor));
     LockedDependencies lockedDependencies = lockFile.read(getLog());


### PR DESCRIPTION
The error message was still referring to the 'lock' goal instead of the 'create-lock-file' goal