### PR TITLE
Pointing to schemas in this git repo

### DIFF
--- a/src/main/resources/maven-v4_0_0_ext.xsd
+++ b/src/main/resources/maven-v4_0_0_ext.xsd
@@ -1,0 +1,21 @@
+<xs:schema
+        targetNamespace="http://maven.apache.org/POM/4.0.0"
+        elementFormDefault="qualified"
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:dependency-lock="urn:se.vandmo.dependencylock">
+
+  <xs:import schemaLocation="https://raw.githubusercontent.com/vandmo/dependency-lock-maven-plugin/master/src/main/resources/vandmo_dependencylock.xsd" namespace="urn:se.vandmo.dependencylock"/>
+
+  <xs:redefine schemaLocation="http://maven.apache.org/maven-v4_0_0.xsd">
+    <xs:complexType name="Dependency">
+      <xs:complexContent>
+        <xs:extension base="Dependency">
+          <xs:all>
+            <xs:element ref="dependency-lock:integrity" minOccurs="0" maxOccurs="1" />
+          </xs:all>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:redefine>
+
+</xs:schema>

--- a/src/main/resources/se/vandmo/dependencylock/maven/pom/pom.ftlx
+++ b/src/main/resources/se/vandmo/dependencylock/maven/pom/pom.ftlx
@@ -2,7 +2,9 @@
 <project
   xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
+  xsi:schemaLocation="
+  http://maven.apache.org/POM/4.0.0 https://raw.githubusercontent.com/vandmo/dependency-lock-maven-plugin/master/src/main/resources/maven-v4_0_0_ext.xsd
+  urn:se.vandmo.dependencylock https://raw.githubusercontent.com/vandmo/dependency-lock-maven-plugin/master/src/main/resources/vandmo_dependencylock.xsd"
   xmlns:dependency-lock="urn:se.vandmo.dependencylock">
   <modelVersion>4.0.0</modelVersion>
 

--- a/src/main/resources/vandmo_dependencylock.xsd
+++ b/src/main/resources/vandmo_dependencylock.xsd
@@ -1,0 +1,8 @@
+<xs:schema
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        elementFormDefault="qualified"
+        targetNamespace="urn:se.vandmo.dependencylock">
+
+    <xs:element name="integrity" type="xs:string" />
+
+</xs:schema>


### PR DESCRIPTION
## Description

Override the maven XML schema for dependency-lock pom files, and add a schema for the `dependency-lock:integrity` element. This avoids a bunch of warnings when opening the dependency-lock pom file in an editor, for example.

The `xsi:schemaLocation` attribute points to the `master` branch in this repository.

<img width="772" alt="Screenshot 2025-03-02 at 23 01 30" src="https://github.com/user-attachments/assets/f06d4403-2327-474f-a655-34121a943f37" />
