### PR TITLE
Adding `version` attribute to project model.

### DIFF
--- a/dependencylock.xsd
+++ b/dependencylock.xsd
@@ -4,5 +4,17 @@
   targetNamespace="urn:se.vandmo.dependencylock">
 
   <xs:element name="integrity" type="xs:string" />
+  
+  <xs:attribute name="version">
+    <xs:simpleType>
+      <xs:restriction base="xs:string">
+        <xs:enumeration value="2">
+          <xs:annotation>
+            <xs:documentation>Value being used when lockfile contains also covers build artifacts.</xs:documentation>
+          </xs:annotation>
+        </xs:enumeration>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
 
 </xs:schema>

--- a/maven-v4_0_0_ext.xsd
+++ b/maven-v4_0_0_ext.xsd
@@ -4,9 +4,16 @@
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:dependency-lock="urn:se.vandmo.dependencylock">
 
-  <xs:import schemaLocation="https://vandmo.github.io/dependency-lock-maven-plugin/dependencylock.xsd" namespace="urn:se.vandmo.dependencylock" />
+  <xs:import schemaLocation="./dependencylock.xsd" namespace="urn:se.vandmo.dependencylock" />
 
   <xs:redefine schemaLocation="http://maven.apache.org/maven-v4_0_0.xsd">
+    <xs:complexType name="Model">
+      <xs:complexContent>
+        <xs:extension base="Model">
+          <xs:attribute ref="dependency-lock:version" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
     <xs:complexType name="Dependency">
       <xs:complexContent>
         <xs:extension base="Dependency">

--- a/maven-v4_0_0_ext.xsd
+++ b/maven-v4_0_0_ext.xsd
@@ -4,7 +4,7 @@
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:dependency-lock="urn:se.vandmo.dependencylock">
 
-  <xs:import schemaLocation="./dependencylock.xsd" namespace="urn:se.vandmo.dependencylock" />
+  <xs:import schemaLocation="https://vandmo.github.io/dependency-lock-maven-plugin/dependencylock.xsd" namespace="urn:se.vandmo.dependencylock" />
 
   <xs:redefine schemaLocation="http://maven.apache.org/maven-v4_0_0.xsd">
     <xs:complexType name="Model">


### PR DESCRIPTION
Provides support with a `version` extra attribute to root project nodes.

This is required to be able to implement #87 for POM format