### PR TITLE
fix: crash when profile with no build is processed

### DIFF
--- a/src/main/java/se/vandmo/dependencylock/maven/mojos/LockProjectHelper.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/mojos/LockProjectHelper.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.BuildBase;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginManagement;
 import org.apache.maven.model.Profile;
@@ -102,7 +103,11 @@ final class LockProjectHelper {
     for (Profile profile : profiles) {
       final Map<String, String> potentialProfilePluginVersions =
           new HashMap<>(baseProfilePluginVersions);
-      final PluginManagement profilePluginManagement = profile.getBuild().getPluginManagement();
+      final BuildBase profileBuild = profile.getBuild();
+      if (profileBuild == null) {
+        continue;
+      }
+      final PluginManagement profilePluginManagement = profileBuild.getPluginManagement();
       if (profilePluginManagement != null) {
         profilePluginManagement
             .getPluginsAsMap()
@@ -120,7 +125,7 @@ final class LockProjectHelper {
                   }
                 });
       }
-      for (Plugin plugin : profile.getBuild().getPlugins()) {
+      for (Plugin plugin : profileBuild.getPlugins()) {
         if (null != plugin.getVersion()) {
           final String pluginId = plugin.getId();
           if (!declaredPlugins.containsKey(pluginId)) {

--- a/src/test/java/se/vandmo/dependencylock/maven/mojos/LockProjectHelperTest.java
+++ b/src/test/java/se/vandmo/dependencylock/maven/mojos/LockProjectHelperTest.java
@@ -79,6 +79,23 @@ public class LockProjectHelperTest {
                 is("org.apache.maven.plugins:maven-invoker-plugin:maven-plugin:3.9.0"))));
     Mockito.verifyNoInteractions(log);
   }
+  
+  @Test
+  @WithoutMojo
+  public void loadPlugins_supportsProfileWithNoBuild() throws Exception {
+    final MavenProject mavenProject = mavenProject();
+    final Log log = Mockito.mock(Log.class);
+    final MavenPluginManager mavenPluginManager = mockMavenPluginManager();
+    final LockProjectHelper projectHelper =
+            new LockProjectHelper(log, mavenPluginManager, mojoRule.newMavenSession(mavenProject));
+    assertThat(
+            projectHelper.loadPlugins(mavenProject),
+            hasItem(
+                    hasProperty(
+                            "artifactKey",
+                            is("org.apache.maven.plugins:maven-invoker-plugin:maven-plugin:3.9.0"))));
+    Mockito.verifyNoInteractions(log);
+  }
 
   private MavenPluginManager mockMavenPluginManager()
       throws PluginResolutionException,

--- a/src/test/resources/se/vandmo/dependencylock/maven/mojos/LockProjectHelperTest/loadPlugins_supportsProfileWithNoBuild.xml
+++ b/src/test/resources/se/vandmo/dependencylock/maven/mojos/LockProjectHelperTest/loadPlugins_supportsProfileWithNoBuild.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>pom-with-profile-plugin-missing</artifactId>
+  <groupId>se.vandmo.tests</groupId>
+  <version>0-SNAPSHOT</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <version>3.9.0</version>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>some-random-profile</id>
+    </profile>
+  </profiles>
+</project>

--- a/src/test/resources/se/vandmo/dependencylock/maven/mojos/LockProjectHelperTest/loadPlugins_supportsProfileWithNoBuild.xml
+++ b/src/test/resources/se/vandmo/dependencylock/maven/mojos/LockProjectHelperTest/loadPlugins_supportsProfileWithNoBuild.xml
@@ -5,7 +5,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>pom-with-profile-plugin-missing</artifactId>
+  <artifactId>pom-with-profile-with-no-build</artifactId>
   <groupId>se.vandmo.tests</groupId>
   <version>0-SNAPSHOT</version>
 


### PR DESCRIPTION
Basically whenever trying to use `lockBuild`with a profile with no build attached it would be ... crashing with an NPE.

```
[ERROR] Failed to execute goal se.vandmo:dependency-lock-maven-plugin:0.0.5734cd9bd748d0121eda3d28d4f428a246501ee0:lock (default-cli) on project parent: Execution default-cli of goal se.vandmo:dependency-lock-maven-plugin:0.0.5734cd9bd748d0121eda3d28d4f428a246501ee0:lock failed: Cannot invoke "org.apache.maven.model.BuildBase.getPluginManagement()" because the return value of "org.apache.maven.model.Profile.getBuild()" is null -> [Help 1]
[E
```