### PR TITLE
Fix URL used for maven POM 4.0.0's XSD to use the eventual one

### DIFF
--- a/maven-v4_0_0_ext.xsd
+++ b/maven-v4_0_0_ext.xsd
@@ -6,7 +6,7 @@
 
   <xs:import schemaLocation="https://vandmo.github.io/dependency-lock-maven-plugin/dependencylock.xsd" namespace="urn:se.vandmo.dependencylock" />
 
-  <xs:redefine schemaLocation="http://maven.apache.org/maven-v4_0_0.xsd">
+  <xs:redefine schemaLocation="https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <xs:complexType name="Model">
       <xs:complexContent>
         <xs:extension base="Model">


### PR DESCRIPTION
There are two issues with the currently used URL: 

1. http protocol is not enabled by default in JRE SchemaFactory default implementation
2. it's actually a redirection to the `https://maven.apache.org/xsd/maven-4.0.0.xsd` one (and this is not supported by the JRE SchemaFactory algorithm to resolve resources)

With this PR the resolution is transparent.