### PR TITLE
chore: fix the `deploy-site` to only run on release tags and fix `release` job to not run site deployment

### DIFF
--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -26,6 +26,7 @@ jobs:
 
   deploy-site:
     needs: test
+    if: startsWith(github.ref, 'refs/tags/release-')
     runs-on: ubuntu-latest
     permissions:
       # Required so that the site deployment's GITHUB_TOKEN is provided with appropriate rights

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -86,7 +86,7 @@ jobs:
           versions:set
           --define newVersion=${{ steps.find-version.outputs.no-dash }}
 
-      - run: mvn --batch-mode --activate-profiles sign deploy site-deploy
+      - run: mvn --batch-mode --activate-profiles sign deploy
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}


### PR DESCRIPTION
This PR does two things:

1. Ensure the `deploy-site` job only runs on the same condition as the `release` job
2. Ensure the `release` job doesn't invoke the maven `site-deploy` phase (e.g. the maven site lifecycle deployment) and leave that to the `deploy-site` job