### PR TITLE
chore: add streaming of logs in case of unexpected failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -762,6 +762,7 @@
             <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
             <addTestClassPath>true</addTestClassPath>
             <debug>true</debug>
+            <streamLogsOnFailures>true</streamLogsOnFailures>
             <properties>
               <maven.compiler.source>1.8</maven.compiler.source>
               <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
We were always "hiding" the logs of builds, even if they failed. This introduced "blindness" to integration test failures.

There were two possibilities:

1. Attach build logs as job artifacts
2. Stream build logs when failing

The former one seemed potentially more expensive in terms of github usage so I went for the latter.