### PR TITLE
fix: unexpected messages found for expectations vs actual checks on plugins, extensions and parents

### DIFF
--- a/src/main/java/se/vandmo/dependencylock/maven/mojos/CheckMojo.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/mojos/CheckMojo.java
@@ -57,22 +57,22 @@ public final class CheckMojo extends AbstractDependencyLockMojo {
         lockedProject.parents.map(
             lockedParents -> {
               log.info("Checking parents");
-              return LockedParents.from(Parents.from(mavenProject()), getLog())
-                  .compareWith(lockedParents, filters);
+              return LockedParents.from(lockedParents, getLog())
+                  .compareWith(Parents.from(mavenProject()), filters);
             });
     Optional<DiffReport> pluginsDiff =
         lockedProject.plugins.map(
             lockedPlugins -> {
               log.info("Checking plugins");
-              return LockedPlugins.from(projectPlugins(), getLog())
-                  .compareWith(lockedPlugins, filters);
+              return LockedPlugins.from(lockedPlugins, getLog())
+                  .compareWith(projectPlugins(), filters);
             });
     Optional<DiffReport> extensionsDiff =
         lockedProject.extensions.map(
             lockedExtensions -> {
               log.info("Checking extensions");
-              return LockedExtensions.from(projectExtensions(), getLog())
-                  .compareWith(lockedExtensions, filters);
+              return LockedExtensions.from(lockedExtensions, getLog())
+                  .compareWith(projectExtensions(), filters);
             });
     LockedProject.Diff diff =
         new LockedProject.Diff(dependenciesDiff, parentsDiff, pluginsDiff, extensionsDiff);

--- a/src/test/java/se/vandmo/dependencylock/maven/LockedParentsTest.java
+++ b/src/test/java/se/vandmo/dependencylock/maven/LockedParentsTest.java
@@ -1,0 +1,63 @@
+package se.vandmo.dependencylock.maven;
+
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.shared.artifact.filter.StrictPatternIncludesArtifactFilter;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+/**
+ * Unit test class dedicated to the validation of the {@link LockedParents} class.
+ */
+public class LockedParentsTest {
+
+    @Test
+    public void validate_checksumIgnoringAndVersionIgnoringAreSupported() {
+        final Parents expectedParents = new Parents(Collections.singletonList(
+                Parent.builder()
+                        .artifactIdentifier(
+                                ArtifactIdentifier.builder()
+                                        .groupId("com.github.some-groupId")
+                                        .artifactId("whatever-artifactId")
+                                        .type("pom")
+                                        .build()
+                        ).version("1.2.0-SNAPSHOT")
+                        .integrity("sha512:h5VNQl9OruqXka54GCXYJ41fXj/PTarH4nf3YJYMTJjIrupolMoVQtVuAWeOUMHDvIiWVY91x1Gdw4+pJWhrlw==")
+                        .build()
+        ));
+        Parents actualParents = new Parents(Collections.singletonList(
+                Parent.builder()
+                        .artifactIdentifier(
+                                ArtifactIdentifier.builder()
+                                        .groupId("com.github.some-groupId")
+                                        .artifactId("whatever-artifactId")
+                                        .type("pom")
+                                        .build()
+                        ).version("1.2.0")
+                        .integrity("sha512:ypo0tF7QE7splJrj5g+xlA07xOeEGafQaNPgWTicnItmvcFIkdGvDEfl9Ipr0n9XvASXDDAFby6jiSmSEaEuKg==")
+                        .build()
+        ));
+        DiffReport result = LockedParents.from(expectedParents, Mockito.mock(Log.class)).compareWith(actualParents, new Filters(
+                Collections.singletonList(
+                        new DependencySetConfiguration(
+                                new StrictPatternIncludesArtifactFilter(
+                                        Collections.singletonList("com.github.some-groupId")
+                                ),
+                                new StrictPatternIncludesArtifactFilter(Collections.emptyList()),
+                                DependencySetConfiguration.Version.useProjectVersion,
+                                DependencySetConfiguration.Integrity.ignore,
+                                null,
+                                null
+                        )
+                ),
+                "1.2.0"
+        ));
+        Assert.assertEquals(
+                Collections.emptyList(),
+                result.report("parents").collect(Collectors.toList())
+        );
+    }
+}

--- a/src/test/java/se/vandmo/dependencylock/maven/LockedParentsTest.java
+++ b/src/test/java/se/vandmo/dependencylock/maven/LockedParentsTest.java
@@ -1,63 +1,62 @@
 package se.vandmo.dependencylock.maven;
 
+import java.util.Collections;
+import java.util.stream.Collectors;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.shared.artifact.filter.StrictPatternIncludesArtifactFilter;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.util.Collections;
-import java.util.stream.Collectors;
-
-/**
- * Unit test class dedicated to the validation of the {@link LockedParents} class.
- */
+/** Unit test class dedicated to the validation of the {@link LockedParents} class. */
 public class LockedParentsTest {
 
-    @Test
-    public void validate_checksumIgnoringAndVersionIgnoringAreSupported() {
-        final Parents expectedParents = new Parents(Collections.singletonList(
+  @Test
+  public void validate_checksumIgnoringAndVersionIgnoringAreSupported() {
+    final Parents expectedParents =
+        new Parents(
+            Collections.singletonList(
                 Parent.builder()
-                        .artifactIdentifier(
-                                ArtifactIdentifier.builder()
-                                        .groupId("com.github.some-groupId")
-                                        .artifactId("whatever-artifactId")
-                                        .type("pom")
-                                        .build()
-                        ).version("1.2.0-SNAPSHOT")
-                        .integrity("sha512:h5VNQl9OruqXka54GCXYJ41fXj/PTarH4nf3YJYMTJjIrupolMoVQtVuAWeOUMHDvIiWVY91x1Gdw4+pJWhrlw==")
-                        .build()
-        ));
-        Parents actualParents = new Parents(Collections.singletonList(
+                    .artifactIdentifier(
+                        ArtifactIdentifier.builder()
+                            .groupId("com.github.some-groupId")
+                            .artifactId("whatever-artifactId")
+                            .type("pom")
+                            .build())
+                    .version("1.2.0-SNAPSHOT")
+                    .integrity(
+                        "sha512:h5VNQl9OruqXka54GCXYJ41fXj/PTarH4nf3YJYMTJjIrupolMoVQtVuAWeOUMHDvIiWVY91x1Gdw4+pJWhrlw==")
+                    .build()));
+    Parents actualParents =
+        new Parents(
+            Collections.singletonList(
                 Parent.builder()
-                        .artifactIdentifier(
-                                ArtifactIdentifier.builder()
-                                        .groupId("com.github.some-groupId")
-                                        .artifactId("whatever-artifactId")
-                                        .type("pom")
-                                        .build()
-                        ).version("1.2.0")
-                        .integrity("sha512:ypo0tF7QE7splJrj5g+xlA07xOeEGafQaNPgWTicnItmvcFIkdGvDEfl9Ipr0n9XvASXDDAFby6jiSmSEaEuKg==")
-                        .build()
-        ));
-        DiffReport result = LockedParents.from(expectedParents, Mockito.mock(Log.class)).compareWith(actualParents, new Filters(
-                Collections.singletonList(
+                    .artifactIdentifier(
+                        ArtifactIdentifier.builder()
+                            .groupId("com.github.some-groupId")
+                            .artifactId("whatever-artifactId")
+                            .type("pom")
+                            .build())
+                    .version("1.2.0")
+                    .integrity(
+                        "sha512:ypo0tF7QE7splJrj5g+xlA07xOeEGafQaNPgWTicnItmvcFIkdGvDEfl9Ipr0n9XvASXDDAFby6jiSmSEaEuKg==")
+                    .build()));
+    DiffReport result =
+        LockedParents.from(expectedParents, Mockito.mock(Log.class))
+            .compareWith(
+                actualParents,
+                new Filters(
+                    Collections.singletonList(
                         new DependencySetConfiguration(
-                                new StrictPatternIncludesArtifactFilter(
-                                        Collections.singletonList("com.github.some-groupId")
-                                ),
-                                new StrictPatternIncludesArtifactFilter(Collections.emptyList()),
-                                DependencySetConfiguration.Version.useProjectVersion,
-                                DependencySetConfiguration.Integrity.ignore,
-                                null,
-                                null
-                        )
-                ),
-                "1.2.0"
-        ));
-        Assert.assertEquals(
-                Collections.emptyList(),
-                result.report("parents").collect(Collectors.toList())
-        );
-    }
+                            new StrictPatternIncludesArtifactFilter(
+                                Collections.singletonList("com.github.some-groupId")),
+                            new StrictPatternIncludesArtifactFilter(Collections.emptyList()),
+                            DependencySetConfiguration.Version.useProjectVersion,
+                            DependencySetConfiguration.Integrity.ignore,
+                            null,
+                            null)),
+                    "1.2.0"));
+    Assert.assertEquals(
+        Collections.emptyList(), result.report("parents").collect(Collectors.toList()));
+  }
 }


### PR DESCRIPTION
Fixes two issues:

1. The expectation vs actual logs could lead to confusion
2. When using the "use-project-version" parameter for "version" dependency set configuration it would be failing because it was "altering" the wrong instance (e.g. the actual one) to match the project version and it was a noop
