### PR TITLE
fix: marshall use-project-version constraint explicitly

### DIFF
--- a/src/it/json/lock-multi-project-use-project-version/expected-dependencies-lock.json
+++ b/src/it/json/lock-multi-project-use-project-version/expected-dependencies-lock.json
@@ -1,0 +1,3 @@
+{
+  "dependencies" : [ ]
+}

--- a/src/it/json/lock-multi-project-use-project-version/invoker.properties
+++ b/src/it/json/lock-multi-project-use-project-version/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:lock

--- a/src/it/json/lock-multi-project-use-project-version/lock-child-a/expected-dependencies-lock.json
+++ b/src/it/json/lock-multi-project-use-project-version/lock-child-a/expected-dependencies-lock.json
@@ -1,0 +1,44 @@
+{
+  "dependencies" : [ {
+    "groupId" : "se.vandmo.testing",
+    "artifactId" : "a-classified-leaf",
+    "version" : "1.0",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:KDKGxTrNHDhrGZEGDSX2KVkn/2S0u1EBJ1B0jMfeZXZm4yeiNIvUnFdFb9W4X1w5HF7ce9ZqeQCnmHdGfTyk2w==",
+    "classifier" : "classy"
+  }, {
+    "groupId" : "se.vandmo.testing",
+    "artifactId" : "a-third-leaf",
+    "version" : "1.0",
+    "scope" : "test",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:QjAlcrqmdWL88+sTA4UWoLft4SrjCkhDlYR2nk8oGkGeUvubkGQzGDrmURXmQuEzROIb5Y02dI7/a11R5k5ZmQ=="
+  }, {
+    "groupId" : "se.vandmo.testing",
+    "artifactId" : "a-war",
+    "version" : "1.0",
+    "scope" : "compile",
+    "type" : "war",
+    "optional" : false,
+    "integrity" : "sha512:1Lojgkq/rfOAUIaUXKkI4n6P0nkuJGlDj2NVGUaX2fLrBJurCr135hiQNTRRiL+wMnLvPWbKZvPHB2rBI/hTKw=="
+  }, {
+    "groupId" : "se.vandmo.testing",
+    "artifactId" : "another-leaf",
+    "version" : "1.0",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : true,
+    "integrity" : "sha512:0TTX1ABvSaYpbW9zHxntUejpMUeFxxod6u0Umg3Ib86RyemGEAbxWKeRtWYCX19BALAHiVr/ArGfy6osTumUOQ=="
+  }, {
+    "groupId" : "se.vandmo.testing",
+    "artifactId" : "leaf",
+    "version" : "1.0",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:98gbCti9u7jp73/lFrslV7BeOCkxeXUiRQT19E58niRlyEKu69BXPXHB/xM8HQu1os08se3xTkbhWXG5xnGMFw=="
+  } ]
+}

--- a/src/it/json/lock-multi-project-use-project-version/lock-child-a/pom.xml
+++ b/src/it/json/lock-multi-project-use-project-version/lock-child-a/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>se.vandmo.tests</groupId>
+    <artifactId>json-lock-multi-project-use-project-version-parent</artifactId>
+    <version>0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>lock-child-a</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>se.vandmo.testing</groupId>
+      <artifactId>leaf</artifactId>
+      <version>1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>se.vandmo.testing</groupId>
+      <artifactId>another-leaf</artifactId>
+      <version>1.0</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>se.vandmo.testing</groupId>
+      <artifactId>a-third-leaf</artifactId>
+      <version>1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>se.vandmo.testing</groupId>
+      <artifactId>a-classified-leaf</artifactId>
+      <version>1.0</version>
+      <classifier>classy</classifier>
+    </dependency>
+    <dependency>
+      <groupId>se.vandmo.testing</groupId>
+      <artifactId>a-war</artifactId>
+      <version>1.0</version>
+      <type>war</type>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/json/lock-multi-project-use-project-version/lock-child-b/expected-dependencies-lock.json
+++ b/src/it/json/lock-multi-project-use-project-version/lock-child-b/expected-dependencies-lock.json
@@ -1,0 +1,36 @@
+{
+  "dependencies" : [ {
+    "groupId" : "se.vandmo.testing",
+    "artifactId" : "a-classified-leaf",
+    "version" : "1.0",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:KDKGxTrNHDhrGZEGDSX2KVkn/2S0u1EBJ1B0jMfeZXZm4yeiNIvUnFdFb9W4X1w5HF7ce9ZqeQCnmHdGfTyk2w==",
+    "classifier" : "classy"
+  }, {
+    "groupId" : "se.vandmo.testing",
+    "artifactId" : "a-war",
+    "version" : "1.0",
+    "scope" : "compile",
+    "type" : "war",
+    "optional" : false,
+    "integrity" : "sha512:1Lojgkq/rfOAUIaUXKkI4n6P0nkuJGlDj2NVGUaX2fLrBJurCr135hiQNTRRiL+wMnLvPWbKZvPHB2rBI/hTKw=="
+  }, {
+    "groupId" : "se.vandmo.testing",
+    "artifactId" : "leaf",
+    "version" : "1.0",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:98gbCti9u7jp73/lFrslV7BeOCkxeXUiRQT19E58niRlyEKu69BXPXHB/xM8HQu1os08se3xTkbhWXG5xnGMFw=="
+  }, {
+    "groupId" : "se.vandmo.tests",
+    "artifactId" : "lock-child-a",
+    "version" : "use-project-version",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "ignored"
+  } ]
+}

--- a/src/it/json/lock-multi-project-use-project-version/lock-child-b/expected-dependencies-lock.json
+++ b/src/it/json/lock-multi-project-use-project-version/lock-child-b/expected-dependencies-lock.json
@@ -27,7 +27,7 @@
   }, {
     "groupId" : "se.vandmo.tests",
     "artifactId" : "lock-child-a",
-    "version" : "use-project-version",
+    "version" : "${project.version}",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,

--- a/src/it/json/lock-multi-project-use-project-version/lock-child-b/pom.xml
+++ b/src/it/json/lock-multi-project-use-project-version/lock-child-b/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>se.vandmo.tests</groupId>
+    <artifactId>json-lock-multi-project-use-project-version-parent</artifactId>
+    <version>0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>lock-child-b</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>se.vandmo.tests</groupId>
+      <artifactId>lock-child-a</artifactId>
+      <version>0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/json/lock-multi-project-use-project-version/pom.xml
+++ b/src/it/json/lock-multi-project-use-project-version/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>se.vandmo.tests</groupId>
+  <artifactId>json-lock-multi-project-use-project-version-parent</artifactId>
+  <version>0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+  </properties>
+  
+  <modules>
+    <module>lock-child-a</module>
+    <module>lock-child-b</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>se.vandmo</groupId>
+        <artifactId>dependency-lock-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <markIgnoredAsIgnored>true</markIgnoredAsIgnored>
+          <dependencySets>
+            <dependencySet>
+              <includes>
+                <include>se.vandmo.tests</include>
+              </includes>
+              <version>use-project-version</version>
+              <integrity>ignore</integrity>
+            </dependencySet>
+          </dependencySets>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/json/lock-multi-project-use-project-version/postbuild.groovy
+++ b/src/it/json/lock-multi-project-use-project-version/postbuild.groovy
@@ -1,0 +1,23 @@
+import static java.nio.charset.StandardCharsets.UTF_8
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.core.CombinableMatcher.both
+import static org.hamcrest.core.IsIterableContaining.hasItem
+import static org.hamcrest.core.StringEndsWith.endsWith
+import static org.hamcrest.core.StringStartsWith.startsWith
+import static org.junit.Assert.assertTrue
+
+import org.apache.commons.io.FileUtils
+
+projectDirs = [basedir, new File(basedir, "lock-child-a"), new File(basedir, "lock-child-b")]
+projectDirs.forEach {projectDir -> {
+    lockFile = new File(projectDir, "dependencies-lock.json")
+    expectedLockFile = new File(projectDir, "expected-dependencies-lock.json")
+
+    assertTrue("Lock file missing", lockFile.isFile())
+    assertTrue("Lock file content not as expected", FileUtils.contentEquals(expectedLockFile, lockFile))
+}}
+
+buildLog = FileUtils.readLines(new File(basedir, "build.log"), UTF_8)
+assertThat(buildLog, hasItem(both(startsWith("[INFO] Creating ")).and(endsWith("/dependency-lock-maven-plugin/target/its/json/lock-multi-project-use-project-version/dependencies-lock.json"))))
+assertThat(buildLog, hasItem(both(startsWith("[INFO] Creating ")).and(endsWith("/dependency-lock-maven-plugin/target/its/json/lock-multi-project-use-project-version/lock-child-a/dependencies-lock.json"))))
+assertThat(buildLog, hasItem(both(startsWith("[INFO] Creating ")).and(endsWith("/dependency-lock-maven-plugin/target/its/json/lock-multi-project-use-project-version/lock-child-b/dependencies-lock.json"))))

--- a/src/it/json/lock-multi-project/lock-child-b/expected-dependencies-lock.json
+++ b/src/it/json/lock-multi-project/lock-child-b/expected-dependencies-lock.json
@@ -10,14 +10,6 @@
     "classifier" : "classy"
   }, {
     "groupId" : "se.vandmo.testing",
-    "artifactId" : "a-third-leaf",
-    "version" : "1.0",
-    "scope" : "test",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:QjAlcrqmdWL88+sTA4UWoLft4SrjCkhDlYR2nk8oGkGeUvubkGQzGDrmURXmQuEzROIb5Y02dI7/a11R5k5ZmQ=="
-  }, {
-    "groupId" : "se.vandmo.testing",
     "artifactId" : "a-war",
     "version" : "1.0",
     "scope" : "compile",
@@ -26,19 +18,19 @@
     "integrity" : "sha512:1Lojgkq/rfOAUIaUXKkI4n6P0nkuJGlDj2NVGUaX2fLrBJurCr135hiQNTRRiL+wMnLvPWbKZvPHB2rBI/hTKw=="
   }, {
     "groupId" : "se.vandmo.testing",
-    "artifactId" : "another-leaf",
-    "version" : "1.0",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : true,
-    "integrity" : "sha512:0TTX1ABvSaYpbW9zHxntUejpMUeFxxod6u0Umg3Ib86RyemGEAbxWKeRtWYCX19BALAHiVr/ArGfy6osTumUOQ=="
-  }, {
-    "groupId" : "se.vandmo.testing",
     "artifactId" : "leaf",
     "version" : "1.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:98gbCti9u7jp73/lFrslV7BeOCkxeXUiRQT19E58niRlyEKu69BXPXHB/xM8HQu1os08se3xTkbhWXG5xnGMFw=="
+  }, {
+    "groupId" : "se.vandmo.tests",
+    "artifactId" : "lock-child-a",
+    "version" : "0-SNAPSHOT",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "ignored"
   } ]
 }

--- a/src/it/json/lock-multi-project/postbuild.groovy
+++ b/src/it/json/lock-multi-project/postbuild.groovy
@@ -10,8 +10,8 @@ import org.apache.commons.io.FileUtils
 
 projectDirs = [basedir, new File(basedir, "lock-child-a"), new File(basedir, "lock-child-b")]
 projectDirs.forEach {projectDir -> {
-    lockFile = new File(basedir, "dependencies-lock.json")
-    expectedLockFile = new File(basedir, "expected-dependencies-lock.json")
+    lockFile = new File(projectDir, "dependencies-lock.json")
+    expectedLockFile = new File(projectDir, "expected-dependencies-lock.json")
 
     assertTrue("Lock file missing", lockFile.isFile())
     assertTrue("Lock file content not as expected", FileUtils.contentEquals(expectedLockFile, lockFile))

--- a/src/it/pom/lock-multi-project-use-project-version/expected/pom.xml
+++ b/src/it/pom/lock-multi-project-use-project-version/expected/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="
+    http://maven.apache.org/POM/4.0.0 https://vandmo.github.io/dependency-lock-maven-plugin/maven-4_0_0_ext.xsd
+    urn:se.vandmo.dependencylock https://vandmo.github.io/dependency-lock-maven-plugin/dependencylock.xsd"
+  xmlns:dependency-lock="urn:se.vandmo.dependencylock"
+  dependency-lock:version="2">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>se.vandmo.tests</groupId>
+  <artifactId>pom-lock-multi-project-use-project-version-parent-dependency-lock</artifactId>
+  <version>0-SNAPSHOT</version>
+
+  <dependencies>
+  </dependencies>
+
+</project>

--- a/src/it/pom/lock-multi-project-use-project-version/invoker.properties
+++ b/src/it/pom/lock-multi-project-use-project-version/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:lock

--- a/src/it/pom/lock-multi-project-use-project-version/lock-child-a/expected/pom.xml
+++ b/src/it/pom/lock-multi-project-use-project-version/lock-child-a/expected/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="
+    http://maven.apache.org/POM/4.0.0 https://vandmo.github.io/dependency-lock-maven-plugin/maven-4_0_0_ext.xsd
+    urn:se.vandmo.dependencylock https://vandmo.github.io/dependency-lock-maven-plugin/dependencylock.xsd"
+  xmlns:dependency-lock="urn:se.vandmo.dependencylock"
+  dependency-lock:version="2">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>se.vandmo.tests</groupId>
+  <artifactId>lock-child-a-dependency-lock</artifactId>
+  <version>0-SNAPSHOT</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>se.vandmo.testing</groupId>
+      <artifactId>a-classified-leaf</artifactId>
+      <version>1.0</version>
+      <type>jar</type>
+      <scope>compile</scope>
+      <classifier>classy</classifier>
+      <optional>false</optional>
+      <dependency-lock:integrity>sha512:KDKGxTrNHDhrGZEGDSX2KVkn/2S0u1EBJ1B0jMfeZXZm4yeiNIvUnFdFb9W4X1w5HF7ce9ZqeQCnmHdGfTyk2w==</dependency-lock:integrity>
+    </dependency>
+    <dependency>
+      <groupId>se.vandmo.testing</groupId>
+      <artifactId>a-third-leaf</artifactId>
+      <version>1.0</version>
+      <type>jar</type>
+      <scope>test</scope>
+      <optional>false</optional>
+      <dependency-lock:integrity>sha512:QjAlcrqmdWL88+sTA4UWoLft4SrjCkhDlYR2nk8oGkGeUvubkGQzGDrmURXmQuEzROIb5Y02dI7/a11R5k5ZmQ==</dependency-lock:integrity>
+    </dependency>
+    <dependency>
+      <groupId>se.vandmo.testing</groupId>
+      <artifactId>a-war</artifactId>
+      <version>1.0</version>
+      <type>war</type>
+      <scope>compile</scope>
+      <optional>false</optional>
+      <dependency-lock:integrity>sha512:1Lojgkq/rfOAUIaUXKkI4n6P0nkuJGlDj2NVGUaX2fLrBJurCr135hiQNTRRiL+wMnLvPWbKZvPHB2rBI/hTKw==</dependency-lock:integrity>
+    </dependency>
+    <dependency>
+      <groupId>se.vandmo.testing</groupId>
+      <artifactId>another-leaf</artifactId>
+      <version>1.0</version>
+      <type>jar</type>
+      <scope>compile</scope>
+      <optional>true</optional>
+      <dependency-lock:integrity>sha512:0TTX1ABvSaYpbW9zHxntUejpMUeFxxod6u0Umg3Ib86RyemGEAbxWKeRtWYCX19BALAHiVr/ArGfy6osTumUOQ==</dependency-lock:integrity>
+    </dependency>
+    <dependency>
+      <groupId>se.vandmo.testing</groupId>
+      <artifactId>leaf</artifactId>
+      <version>1.0</version>
+      <type>jar</type>
+      <scope>compile</scope>
+      <optional>false</optional>
+      <dependency-lock:integrity>sha512:98gbCti9u7jp73/lFrslV7BeOCkxeXUiRQT19E58niRlyEKu69BXPXHB/xM8HQu1os08se3xTkbhWXG5xnGMFw==</dependency-lock:integrity>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/pom/lock-multi-project-use-project-version/lock-child-a/pom.xml
+++ b/src/it/pom/lock-multi-project-use-project-version/lock-child-a/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>se.vandmo.tests</groupId>
+    <artifactId>pom-lock-multi-project-use-project-version-parent</artifactId>
+    <version>0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>lock-child-a</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>se.vandmo.testing</groupId>
+      <artifactId>leaf</artifactId>
+      <version>1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>se.vandmo.testing</groupId>
+      <artifactId>another-leaf</artifactId>
+      <version>1.0</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>se.vandmo.testing</groupId>
+      <artifactId>a-third-leaf</artifactId>
+      <version>1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>se.vandmo.testing</groupId>
+      <artifactId>a-classified-leaf</artifactId>
+      <version>1.0</version>
+      <classifier>classy</classifier>
+    </dependency>
+    <dependency>
+      <groupId>se.vandmo.testing</groupId>
+      <artifactId>a-war</artifactId>
+      <version>1.0</version>
+      <type>war</type>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/pom/lock-multi-project-use-project-version/lock-child-b/expected/pom.xml
+++ b/src/it/pom/lock-multi-project-use-project-version/lock-child-b/expected/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>se.vandmo.tests</groupId>
       <artifactId>lock-child-a</artifactId>
-      <version>project-version</version>
+      <version>${project.version}</version>
       <type>jar</type>
       <scope>compile</scope>
       <optional>false</optional>

--- a/src/it/pom/lock-multi-project-use-project-version/lock-child-b/expected/pom.xml
+++ b/src/it/pom/lock-multi-project-use-project-version/lock-child-b/expected/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="
+    http://maven.apache.org/POM/4.0.0 https://vandmo.github.io/dependency-lock-maven-plugin/maven-4_0_0_ext.xsd
+    urn:se.vandmo.dependencylock https://vandmo.github.io/dependency-lock-maven-plugin/dependencylock.xsd"
+  xmlns:dependency-lock="urn:se.vandmo.dependencylock"
+  dependency-lock:version="2">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>se.vandmo.tests</groupId>
+  <artifactId>lock-child-b-dependency-lock</artifactId>
+  <version>0-SNAPSHOT</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>se.vandmo.testing</groupId>
+      <artifactId>a-classified-leaf</artifactId>
+      <version>1.0</version>
+      <type>jar</type>
+      <scope>compile</scope>
+      <classifier>classy</classifier>
+      <optional>false</optional>
+      <dependency-lock:integrity>sha512:KDKGxTrNHDhrGZEGDSX2KVkn/2S0u1EBJ1B0jMfeZXZm4yeiNIvUnFdFb9W4X1w5HF7ce9ZqeQCnmHdGfTyk2w==</dependency-lock:integrity>
+    </dependency>
+    <dependency>
+      <groupId>se.vandmo.testing</groupId>
+      <artifactId>a-war</artifactId>
+      <version>1.0</version>
+      <type>war</type>
+      <scope>compile</scope>
+      <optional>false</optional>
+      <dependency-lock:integrity>sha512:1Lojgkq/rfOAUIaUXKkI4n6P0nkuJGlDj2NVGUaX2fLrBJurCr135hiQNTRRiL+wMnLvPWbKZvPHB2rBI/hTKw==</dependency-lock:integrity>
+    </dependency>
+    <dependency>
+      <groupId>se.vandmo.testing</groupId>
+      <artifactId>leaf</artifactId>
+      <version>1.0</version>
+      <type>jar</type>
+      <scope>compile</scope>
+      <optional>false</optional>
+      <dependency-lock:integrity>sha512:98gbCti9u7jp73/lFrslV7BeOCkxeXUiRQT19E58niRlyEKu69BXPXHB/xM8HQu1os08se3xTkbhWXG5xnGMFw==</dependency-lock:integrity>
+    </dependency>
+    <dependency>
+      <groupId>se.vandmo.tests</groupId>
+      <artifactId>lock-child-a</artifactId>
+      <version>project-version</version>
+      <type>jar</type>
+      <scope>compile</scope>
+      <optional>false</optional>
+      <dependency-lock:integrity>ignored</dependency-lock:integrity>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/pom/lock-multi-project-use-project-version/lock-child-b/pom.xml
+++ b/src/it/pom/lock-multi-project-use-project-version/lock-child-b/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>se.vandmo.tests</groupId>
+    <artifactId>pom-lock-multi-project-use-project-version-parent</artifactId>
+    <version>0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>lock-child-b</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>se.vandmo.tests</groupId>
+      <artifactId>lock-child-a</artifactId>
+      <version>0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/pom/lock-multi-project-use-project-version/pom.xml
+++ b/src/it/pom/lock-multi-project-use-project-version/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>se.vandmo.tests</groupId>
+  <artifactId>pom-lock-multi-project-use-project-version-parent</artifactId>
+  <version>0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+  </properties>
+  
+  <modules>
+    <module>lock-child-a</module>
+    <module>lock-child-b</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>se.vandmo</groupId>
+        <artifactId>dependency-lock-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <markIgnoredAsIgnored>true</markIgnoredAsIgnored>
+          <format>pom</format>
+          <dependencySets>
+            <dependencySet>
+              <includes>
+                <include>se.vandmo.tests</include>
+              </includes>
+              <version>use-project-version</version>
+              <integrity>ignore</integrity>
+            </dependencySet>
+          </dependencySets>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/pom/lock-multi-project-use-project-version/postbuild.groovy
+++ b/src/it/pom/lock-multi-project-use-project-version/postbuild.groovy
@@ -1,0 +1,33 @@
+import static java.nio.charset.StandardCharsets.UTF_8
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.core.CombinableMatcher.both
+import static org.hamcrest.core.IsIterableContaining.hasItem
+import static org.hamcrest.core.StringEndsWith.endsWith
+import static org.hamcrest.core.StringStartsWith.startsWith
+import static org.junit.Assert.assertTrue
+
+import org.apache.commons.io.FileUtils
+
+def projectDirs = [basedir, new File(basedir, "lock-child-b"), new File(basedir, "lock-child-a")]
+projectDirs.each { projectDir ->
+    lockFile = new File(projectDir, ".dependency-lock/pom.xml")
+    expectedLockFile = new File(projectDir, "expected/pom.xml")
+
+    assertTrue(lockFile.isFile())
+    assertTrue("Unexpected differences found between expected ${expectedLockFile} and ${lockFile}", FileUtils.contentEquals(expectedLockFile, lockFile))
+}
+
+buildLog = FileUtils.readLines(new File(basedir, "build.log"), UTF_8)
+assertThat(buildLog,
+        hasItem(both(startsWith("[INFO] Creating ")).and(
+                endsWith("/dependency-lock-maven-plugin/target/its/pom/lock-multi-project-use-project-version/.dependency-lock/pom.xml")))
+)
+assertThat(buildLog,
+        hasItem(both(startsWith("[INFO] Creating ")).and(
+                endsWith("/dependency-lock-maven-plugin/target/its/pom/lock-multi-project-use-project-version/lock-child-b/.dependency-lock/pom.xml")))
+)
+
+assertThat(buildLog,
+        hasItem(both(startsWith("[INFO] Creating ")).and(
+                endsWith("/dependency-lock-maven-plugin/target/its/pom/lock-multi-project-use-project-version/lock-child-a/.dependency-lock/pom.xml")))
+)

--- a/src/main/java/se/vandmo/dependencylock/maven/AbstractLockedEntries.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/AbstractLockedEntries.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import org.apache.maven.plugin.logging.Log;
+import se.vandmo.dependencylock.maven.versions.VersionConstraint;
 
 /**
  * Base class for entires in charge of performing diff checks.
@@ -27,7 +28,7 @@ public class AbstractLockedEntries<EntityType extends LockableEntity<EntityType>
   final List<String> diffVersion(
       AtomicReference<EntityType> lockedEntityRef,
       EntityType actualEntity,
-      BiFunction<EntityType, String, EntityType> versionUpdater,
+      BiFunction<EntityType, VersionConstraint, EntityType> versionUpdater,
       Filters filters) {
     return diffHelper.diffVersion(lockedEntityRef, actualEntity, versionUpdater, filters);
   }

--- a/src/main/java/se/vandmo/dependencylock/maven/Artifact.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/Artifact.java
@@ -6,11 +6,14 @@ import static se.vandmo.dependencylock.maven.Checksum.ALGORITHM_HEADER;
 
 import java.util.Objects;
 import se.vandmo.dependencylock.maven.lang.Strings;
+import se.vandmo.dependencylock.maven.versions.VersionConstraint;
+import se.vandmo.dependencylock.maven.versions.VersionConstraintVisitor;
+import se.vandmo.dependencylock.maven.versions.VersionConstraints;
 
 public final class Artifact extends LockableEntity<Artifact> implements Comparable<Artifact> {
 
   public final ArtifactIdentifier identifier;
-  public final String version;
+  public final VersionConstraint version;
   public final Integrity integrity;
   private org.apache.maven.artifact.Artifact mavenArtifact;
 
@@ -34,15 +37,20 @@ public final class Artifact extends LockableEntity<Artifact> implements Comparab
     }
 
     public IntegrityBuilderStage version(String version) {
+      return version(VersionConstraints.version(version));
+    }
+
+    public IntegrityBuilderStage version(VersionConstraint version) {
       return new IntegrityBuilderStage(artifactIdentifier, requireNonNull(version));
     }
   }
 
   public static final class IntegrityBuilderStage {
     private final ArtifactIdentifier artifactIdentifier;
-    private final String version;
+    private final VersionConstraint version;
 
-    private IntegrityBuilderStage(ArtifactIdentifier artifactIdentifier, String version) {
+    private IntegrityBuilderStage(
+        ArtifactIdentifier artifactIdentifier, VersionConstraint version) {
       this.artifactIdentifier = artifactIdentifier;
       this.version = version;
     }
@@ -68,11 +76,11 @@ public final class Artifact extends LockableEntity<Artifact> implements Comparab
 
   public static final class FinalBuilderStage {
     private final ArtifactIdentifier artifactIdentifier;
-    private final String version;
+    private final VersionConstraint version;
     private final Integrity integrity;
 
     private FinalBuilderStage(
-        ArtifactIdentifier artifactIdentifier, String version, Integrity integrity) {
+        ArtifactIdentifier artifactIdentifier, VersionConstraint version, Integrity integrity) {
       this.artifactIdentifier = artifactIdentifier;
       this.version = version;
       this.integrity = integrity;
@@ -95,7 +103,7 @@ public final class Artifact extends LockableEntity<Artifact> implements Comparab
             .classifier(ofNullable(artifact.getClassifier()))
             .type(ofNullable(artifact.getType()))
             .build(),
-        artifact.getVersion(),
+        VersionConstraints.version(artifact.getVersion()),
         integrity);
   }
 
@@ -108,13 +116,14 @@ public final class Artifact extends LockableEntity<Artifact> implements Comparab
     return result;
   }
 
-  private Artifact(ArtifactIdentifier identifier, String version, Integrity integrity) {
+  private Artifact(ArtifactIdentifier identifier, VersionConstraint version, Integrity integrity) {
     this.identifier = requireNonNull(identifier);
     this.version = requireNonNull(version);
     this.integrity = integrity;
   }
 
-  public Artifact withVersion(String version) {
+  @Override
+  public Artifact withVersion(VersionConstraint version) {
     return new Artifact(identifier, version, integrity);
   }
 
@@ -189,7 +198,7 @@ public final class Artifact extends LockableEntity<Artifact> implements Comparab
   }
 
   @Override
-  public String getVersion() {
+  public VersionConstraint getVersion() {
     return version;
   }
 
@@ -234,5 +243,22 @@ public final class Artifact extends LockableEntity<Artifact> implements Comparab
       return false;
     }
     return true;
+  }
+
+  private static class VersionToString implements VersionConstraintVisitor<String, Void> {
+    @Override
+    public String onVersion(String version, Void context) {
+      return version;
+    }
+
+    @Override
+    public String onProjectVersion(Void context) {
+      return "project-version";
+    }
+
+    @Override
+    public String onIgnoreVersion(Void context) {
+      return "ignored";
+    }
   }
 }

--- a/src/main/java/se/vandmo/dependencylock/maven/Dependency.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/Dependency.java
@@ -3,6 +3,7 @@ package se.vandmo.dependencylock.maven;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
+import se.vandmo.dependencylock.maven.versions.VersionConstraint;
 
 public final class Dependency extends LockableEntityWithArtifact<Dependency>
     implements Comparable<Dependency> {
@@ -114,7 +115,8 @@ public final class Dependency extends LockableEntityWithArtifact<Dependency>
     this.optional = optional;
   }
 
-  public Dependency withVersion(String version) {
+  @Override
+  public Dependency withVersion(VersionConstraint version) {
     return new Dependency(this.artifact.withVersion(version), scope, optional);
   }
 

--- a/src/main/java/se/vandmo/dependencylock/maven/Dependency.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/Dependency.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 import se.vandmo.dependencylock.maven.versions.VersionConstraint;
+import se.vandmo.dependencylock.maven.versions.VersionConstraints;
 
 public final class Dependency extends LockableEntityWithArtifact<Dependency>
     implements Comparable<Dependency> {
@@ -34,6 +35,10 @@ public final class Dependency extends LockableEntityWithArtifact<Dependency>
     }
 
     public IntegrityBuilderStage version(String version) {
+      return version(VersionConstraints.version(version));
+    }
+
+    public IntegrityBuilderStage version(VersionConstraint version) {
       return new IntegrityBuilderStage(artifactBuilder.version(version));
     }
   }

--- a/src/main/java/se/vandmo/dependencylock/maven/DiffHelper.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/DiffHelper.java
@@ -62,7 +62,7 @@ final class DiffHelper {
   <EntityType extends LockableEntity<EntityType>> List<String> diffVersion(
       AtomicReference<EntityType> lockedEntityRef,
       EntityType actualEntity,
-      BiFunction<EntityType, String, EntityType> versionUpdater,
+      BiFunction<EntityType, VersionConstraint, EntityType> versionUpdater,
       Filters filters) {
     EntityType lockedDependency = lockedEntityRef.get();
     Filters.VersionConfiguration versionConfiguration =
@@ -77,7 +77,7 @@ final class DiffHelper {
       case useProjectVersion:
         log.info(format(ROOT, "Using project version for %s", lockedDependency));
         lockedEntityRef.set(
-            versionUpdater.apply(lockedDependency, versionConfiguration.projectVersion));
+            versionUpdater.apply(lockedDependency, VersionConstraints.version(versionConfiguration.projectVersion)));
         if (VersionConstraints.useProjectVersion()
             .compliantWith(actualEntity.getVersion(), filters)) {
           return emptyList();

--- a/src/main/java/se/vandmo/dependencylock/maven/DiffHelper.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/DiffHelper.java
@@ -11,12 +11,18 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import org.apache.maven.plugin.logging.Log;
+import se.vandmo.dependencylock.maven.versions.VersionConstraint;
+import se.vandmo.dependencylock.maven.versions.VersionConstraintContext;
+import se.vandmo.dependencylock.maven.versions.VersionConstraintVisitor;
+import se.vandmo.dependencylock.maven.versions.VersionConstraints;
 
 final class DiffHelper {
   private final Log log;
+  private final VersionConstraintWithSnapshotConstraintRelaxed withSnapshotConstraintRelaxed;
 
   DiffHelper(Log log) {
     this.log = log;
+    this.withSnapshotConstraintRelaxed = new VersionConstraintWithSnapshotConstraintRelaxed();
   }
 
   <T extends LockableEntity<T>> List<String> diffIntegrity(
@@ -63,7 +69,7 @@ final class DiffHelper {
         filters.versionConfiguration(lockedDependency);
     switch (versionConfiguration.type) {
       case check:
-        if (lockedDependency.getVersion().equals(actualEntity.getVersion())) {
+        if (lockedDependency.getVersion().compliantWith(actualEntity.getVersion(), filters)) {
           return emptyList();
         } else {
           return singletonList("version");
@@ -72,14 +78,20 @@ final class DiffHelper {
         log.info(format(ROOT, "Using project version for %s", lockedDependency));
         lockedEntityRef.set(
             versionUpdater.apply(lockedDependency, versionConfiguration.projectVersion));
-        if (versionConfiguration.projectVersion.equals(actualEntity.getVersion())) {
+        if (VersionConstraints.useProjectVersion()
+            .compliantWith(actualEntity.getVersion(), filters)) {
           return emptyList();
         } else {
           return singletonList("version (expected project version)");
         }
       case snapshot:
         log.info(format(ROOT, "Allowing snapshot version for %s", lockedDependency));
-        if (VersionUtils.snapshotMatch(lockedDependency.getVersion(), actualEntity.getVersion())) {
+        if (lockedDependency
+            .getVersion()
+            .accept(withSnapshotConstraintRelaxed, filters)
+            .compliantWith(
+                actualEntity.getVersion().accept(withSnapshotConstraintRelaxed, filters),
+                filters)) {
           return emptyList();
         } else {
           return singletonList("version (allowing snapshot version)");
@@ -89,6 +101,28 @@ final class DiffHelper {
         return emptyList();
       default:
         throw new RuntimeException("Unsupported enum value");
+    }
+  }
+
+  /**
+   * Instances of this class shall be used to "downgrade" constraints on a given version to ignore
+   * -SNAPSHOT suffixes.
+   */
+  private static final class VersionConstraintWithSnapshotConstraintRelaxed
+      implements VersionConstraintVisitor<VersionConstraint, VersionConstraintContext> {
+    @Override
+    public VersionConstraint onVersion(String version, VersionConstraintContext context) {
+      return VersionConstraints.version(VersionUtils.stripSnapshot(version));
+    }
+
+    @Override
+    public VersionConstraint onProjectVersion(VersionConstraintContext context) {
+      return onVersion(context.getProjectVersion(), context);
+    }
+
+    @Override
+    public VersionConstraint onIgnoreVersion(VersionConstraintContext context) {
+      return VersionConstraints.ignoreVersion();
     }
   }
 }

--- a/src/main/java/se/vandmo/dependencylock/maven/Extension.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/Extension.java
@@ -3,6 +3,7 @@ package se.vandmo.dependencylock.maven;
 import static java.util.Objects.requireNonNull;
 
 import org.apache.maven.plugin.ExtensionRealmCache;
+import se.vandmo.dependencylock.maven.versions.VersionConstraint;
 
 public final class Extension extends LockableEntityWithArtifact<Extension> {
   public static ArtifactIdentifierBuilderStage builder() {
@@ -69,7 +70,8 @@ public final class Extension extends LockableEntityWithArtifact<Extension> {
     super(artifact);
   }
 
-  public Extension withVersion(String version) {
+  @Override
+  public Extension withVersion(VersionConstraint version) {
     return new Extension(artifact.withVersion(version));
   }
 }

--- a/src/main/java/se/vandmo/dependencylock/maven/Extension.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/Extension.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.apache.maven.plugin.ExtensionRealmCache;
 import se.vandmo.dependencylock.maven.versions.VersionConstraint;
+import se.vandmo.dependencylock.maven.versions.VersionConstraints;
 
 public final class Extension extends LockableEntityWithArtifact<Extension> {
   public static ArtifactIdentifierBuilderStage builder() {
@@ -38,6 +39,10 @@ public final class Extension extends LockableEntityWithArtifact<Extension> {
     }
 
     public IntegrityBuilderStage version(String version) {
+      return version(VersionConstraints.version(version));
+    }
+
+    public IntegrityBuilderStage version(VersionConstraint version) {
       return new IntegrityBuilderStage(artifactBuilder.version(version));
     }
   }

--- a/src/main/java/se/vandmo/dependencylock/maven/FilterUtils.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/FilterUtils.java
@@ -2,6 +2,8 @@ package se.vandmo.dependencylock.maven;
 
 import static java.util.stream.Collectors.toList;
 
+import se.vandmo.dependencylock.maven.versions.VersionConstraints;
+
 /** Helper methods for applying filters. */
 public final class FilterUtils {
   private FilterUtils() {}
@@ -33,7 +35,7 @@ public final class FilterUtils {
 
   private static <T extends LockableEntity<T>> T modify(T lockableEntity, Filters filters) {
     T result = lockableEntity;
-    result = ignoreVersionIfRelevant(result, filters);
+    result = applyFilterConfiguration(result, filters);
     result = ignoreIntegrityIfRelevant(result, filters);
     return result;
   }
@@ -50,7 +52,7 @@ public final class FilterUtils {
 
   private static Plugin modify(Plugin plugin, Filters filters) {
     Plugin result = plugin;
-    result = ignoreVersionIfRelevant(result, filters);
+    result = applyFilterConfiguration(result, filters);
     result = ignoreIntegrityIfRelevant(result, filters);
     result =
         result.withDependencies(
@@ -61,13 +63,15 @@ public final class FilterUtils {
     return result;
   }
 
-  private static <T extends LockableEntity<T>> T ignoreVersionIfRelevant(
+  private static <T extends LockableEntity<T>> T applyFilterConfiguration(
       T lockableEntity, Filters filters) {
-    if (filters
-        .versionConfiguration(lockableEntity)
-        .type
-        .equals(DependencySetConfiguration.Version.ignore)) {
-      return lockableEntity.withVersion("ignored");
+    final DependencySetConfiguration.Version filteredConfiguration =
+        filters.versionConfiguration(lockableEntity).type;
+    if (filteredConfiguration.equals(DependencySetConfiguration.Version.ignore)) {
+      return lockableEntity.withVersion(VersionConstraints.ignoreVersion());
+    }
+    if (filteredConfiguration.equals(DependencySetConfiguration.Version.useProjectVersion)) {
+      return lockableEntity.withVersion(VersionConstraints.useProjectVersion());
     }
     return lockableEntity;
   }

--- a/src/main/java/se/vandmo/dependencylock/maven/Filters.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/Filters.java
@@ -8,8 +8,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import org.apache.maven.artifact.Artifact;
+import se.vandmo.dependencylock.maven.versions.VersionConstraintContext;
 
-public final class Filters {
+public final class Filters implements VersionConstraintContext {
 
   private final List<DependencySetConfiguration> dependencySetConfigurations;
   private final String projectVersion;
@@ -56,6 +57,11 @@ public final class Filters {
 
   public boolean allowMissing(LockableEntity<?> entity) {
     return configurationFor(entity, d -> d.allowMissing, Boolean.FALSE);
+  }
+
+  @Override
+  public String getProjectVersion() {
+    return this.projectVersion;
   }
 
   public static final class VersionConfiguration {

--- a/src/main/java/se/vandmo/dependencylock/maven/LockableEntity.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/LockableEntity.java
@@ -1,8 +1,6 @@
 package se.vandmo.dependencylock.maven;
 
-import java.util.Objects;
 import se.vandmo.dependencylock.maven.versions.VersionConstraint;
-import se.vandmo.dependencylock.maven.versions.VersionConstraints;
 
 /**
  * Instances of this class shall represent a versioned entity which can be checked for integrity.
@@ -11,11 +9,6 @@ public abstract class LockableEntity<T extends LockableEntity<T>> {
 
   LockableEntity() {
     super();
-  }
-
-  public T withVersion(String version) {
-    return withVersion(
-        VersionConstraints.version(Objects.requireNonNull(version, "version == null")));
   }
 
   public abstract T withVersion(VersionConstraint version);

--- a/src/main/java/se/vandmo/dependencylock/maven/LockableEntity.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/LockableEntity.java
@@ -1,5 +1,9 @@
 package se.vandmo.dependencylock.maven;
 
+import java.util.Objects;
+import se.vandmo.dependencylock.maven.versions.VersionConstraint;
+import se.vandmo.dependencylock.maven.versions.VersionConstraints;
+
 /**
  * Instances of this class shall represent a versioned entity which can be checked for integrity.
  */
@@ -9,13 +13,18 @@ public abstract class LockableEntity<T extends LockableEntity<T>> {
     super();
   }
 
-  public abstract T withVersion(String version);
+  public T withVersion(String version) {
+    return withVersion(
+        VersionConstraints.version(Objects.requireNonNull(version, "version == null")));
+  }
+
+  public abstract T withVersion(VersionConstraint version);
 
   public abstract T withIntegrity(Integrity integrity);
 
   public abstract Integrity getIntegrity();
 
-  public abstract String getVersion();
+  public abstract VersionConstraint getVersion();
 
   public abstract String getArtifactKey();
 

--- a/src/main/java/se/vandmo/dependencylock/maven/LockableEntityWithArtifact.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/LockableEntityWithArtifact.java
@@ -2,6 +2,8 @@ package se.vandmo.dependencylock.maven;
 
 import static java.util.Objects.requireNonNull;
 
+import se.vandmo.dependencylock.maven.versions.VersionConstraint;
+
 /** Instances of this class shall represent a lockable entity which is attached to an artifact. */
 public abstract class LockableEntityWithArtifact<T extends LockableEntityWithArtifact<T>>
     extends LockableEntity<T> {
@@ -17,7 +19,7 @@ public abstract class LockableEntityWithArtifact<T extends LockableEntityWithArt
   public abstract T withIntegrity(Integrity integrity);
 
   @Override
-  public abstract T withVersion(String version);
+  public abstract T withVersion(VersionConstraint version);
 
   @Override
   public final Integrity getIntegrity() {
@@ -25,7 +27,7 @@ public abstract class LockableEntityWithArtifact<T extends LockableEntityWithArt
   }
 
   @Override
-  public final String getVersion() {
+  public final VersionConstraint getVersion() {
     return this.artifact.version;
   }
 

--- a/src/main/java/se/vandmo/dependencylock/maven/MavenArtifact.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/MavenArtifact.java
@@ -12,6 +12,7 @@ import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.VersionRange;
+import se.vandmo.dependencylock.maven.versions.VersionConstraintVisitor;
 
 public final class MavenArtifact implements org.apache.maven.artifact.Artifact {
 
@@ -31,7 +32,8 @@ public final class MavenArtifact implements org.apache.maven.artifact.Artifact {
   private MavenArtifact(se.vandmo.dependencylock.maven.Artifact delegate, String scope) {
     this.delegate = delegate;
     this.scope = scope;
-    this.baseVersion = ArtifactUtils.toSnapshotVersion(delegate.version);
+    this.baseVersion =
+        ArtifactUtils.toSnapshotVersion(delegate.version.accept(new ToPseudoVersion(), null));
   }
 
   @Override
@@ -46,7 +48,7 @@ public final class MavenArtifact implements org.apache.maven.artifact.Artifact {
 
   @Override
   public String getVersion() {
-    return delegate.version;
+    return delegate.version.accept(new ToPseudoVersion(), null);
   }
 
   @Override
@@ -279,5 +281,22 @@ public final class MavenArtifact implements org.apache.maven.artifact.Artifact {
   @Override
   public int hashCode() {
     return Objects.hash(delegate);
+  }
+
+  private static class ToPseudoVersion implements VersionConstraintVisitor<String, Void> {
+    @Override
+    public String onVersion(String version, Void context) {
+      return version;
+    }
+
+    @Override
+    public String onProjectVersion(Void context) {
+      return "project-version";
+    }
+
+    @Override
+    public String onIgnoreVersion(Void context) {
+      return "ignored";
+    }
   }
 }

--- a/src/main/java/se/vandmo/dependencylock/maven/Parent.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/Parent.java
@@ -1,6 +1,8 @@
 package se.vandmo.dependencylock.maven;
 
 import java.util.Objects;
+import se.vandmo.dependencylock.maven.versions.VersionConstraint;
+import se.vandmo.dependencylock.maven.versions.VersionConstraints;
 
 public final class Parent extends LockableEntityWithArtifact<Parent> implements Comparable<Parent> {
   private Parent(Artifact artifact) {
@@ -28,7 +30,8 @@ public final class Parent extends LockableEntityWithArtifact<Parent> implements 
     return Objects.hash(artifact);
   }
 
-  public Parent withVersion(String version) {
+  @Override
+  public Parent withVersion(VersionConstraint version) {
     return new Parent(this.artifact.withVersion(version));
   }
 
@@ -52,6 +55,10 @@ public final class Parent extends LockableEntityWithArtifact<Parent> implements 
     }
 
     public IntegrityBuilderStage version(String version) {
+      return version(VersionConstraints.version(version));
+    }
+
+    public IntegrityBuilderStage version(VersionConstraint version) {
       return new IntegrityBuilderStage(artifactBuilderStage.version(version));
     }
   }

--- a/src/main/java/se/vandmo/dependencylock/maven/Plugin.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/Plugin.java
@@ -3,6 +3,7 @@ package se.vandmo.dependencylock.maven;
 import static java.util.Objects.requireNonNull;
 
 import se.vandmo.dependencylock.maven.versions.VersionConstraint;
+import se.vandmo.dependencylock.maven.versions.VersionConstraints;
 
 public final class Plugin extends LockableEntityWithArtifact<Plugin> {
   public final Artifacts dependencies;
@@ -39,6 +40,10 @@ public final class Plugin extends LockableEntityWithArtifact<Plugin> {
     }
 
     public IntegrityBuilderStage version(String version) {
+      return version(VersionConstraints.version(version));
+    }
+
+    public IntegrityBuilderStage version(VersionConstraint version) {
       return new IntegrityBuilderStage(versionBuilder.version(version));
     }
   }

--- a/src/main/java/se/vandmo/dependencylock/maven/Plugin.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/Plugin.java
@@ -2,6 +2,8 @@ package se.vandmo.dependencylock.maven;
 
 import static java.util.Objects.requireNonNull;
 
+import se.vandmo.dependencylock.maven.versions.VersionConstraint;
+
 public final class Plugin extends LockableEntityWithArtifact<Plugin> {
   public final Artifacts dependencies;
 
@@ -84,7 +86,8 @@ public final class Plugin extends LockableEntityWithArtifact<Plugin> {
     this.dependencies = requireNonNull(dependencies);
   }
 
-  public Plugin withVersion(String version) {
+  @Override
+  public Plugin withVersion(VersionConstraint version) {
     return new Plugin(artifact.withVersion(version), dependencies);
   }
 }

--- a/src/main/java/se/vandmo/dependencylock/maven/json/DependenciesLockFileJson.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/json/DependenciesLockFileJson.java
@@ -18,9 +18,11 @@ import se.vandmo.dependencylock.maven.LockedDependencies;
 public final class DependenciesLockFileJson {
 
   private final LockFileAccessor dependenciesLockFile;
+  private final VersionConstraintJsonSerializer versionConstraintJsonSerializer;
 
   private DependenciesLockFileJson(LockFileAccessor dependenciesLockFile) {
     this.dependenciesLockFile = dependenciesLockFile;
+    this.versionConstraintJsonSerializer = new VersionConstraintJsonSerializer();
   }
 
   public static DependenciesLockFileJson from(LockFileAccessor dependenciesLockFile) {
@@ -28,8 +30,7 @@ public final class DependenciesLockFileJson {
   }
 
   public void write(LockedDependencies lockedDependencies) {
-    ObjectNode json = JsonNodeFactory.instance.objectNode();
-    json.set("dependencies", asJson(lockedDependencies));
+    JsonNode json = toJson(lockedDependencies, JsonNodeFactory.instance);
     try (Writer writer = dependenciesLockFile.writer()) {
       writeJson(writer, json);
     } catch (IOException e) {
@@ -37,20 +38,28 @@ public final class DependenciesLockFileJson {
     }
   }
 
-  private JsonNode asJson(LockedDependencies lockedDependencies) {
-    ArrayNode json = JsonNodeFactory.instance.arrayNode();
+  private JsonNode toJson(LockedDependencies lockedDependencies, JsonNodeFactory nodeFactory) {
+    ObjectNode json = nodeFactory.objectNode();
+    json.set("dependencies", asJson(lockedDependencies, nodeFactory));
+    return json;
+  }
+
+  private JsonNode asJson(LockedDependencies lockedDependencies, JsonNodeFactory nodeFactory) {
+    ArrayNode json = nodeFactory.arrayNode();
     for (Dependency lockedDependency : lockedDependencies.lockedEntities) {
-      json.add(asJson(lockedDependency));
+      json.add(asJson(lockedDependency, nodeFactory));
     }
     return json;
   }
 
-  private JsonNode asJson(Dependency lockedDependency) {
-    ObjectNode json = JsonNodeFactory.instance.objectNode();
+  private JsonNode asJson(Dependency lockedDependency, JsonNodeFactory nodeFactory) {
+    ObjectNode json = nodeFactory.objectNode();
     final ArtifactIdentifier artifactIdentifier = lockedDependency.getArtifactIdentifier();
     json.put("groupId", artifactIdentifier.groupId);
     json.put("artifactId", artifactIdentifier.artifactId);
-    json.put("version", lockedDependency.getVersion());
+    json.set(
+        "version",
+        lockedDependency.getVersion().accept(versionConstraintJsonSerializer, nodeFactory));
     json.put("scope", lockedDependency.scope);
     json.put("type", artifactIdentifier.type);
     json.put("optional", lockedDependency.optional);

--- a/src/main/java/se/vandmo/dependencylock/maven/json/JsonConstants.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/json/JsonConstants.java
@@ -1,0 +1,8 @@
+package se.vandmo.dependencylock.maven.json;
+
+final class JsonConstants {
+  static final String USE_PROJECT_VERSION = "use-project-version";
+  static final String IGNORED = "ignored";
+
+  private JsonConstants() {}
+}

--- a/src/main/java/se/vandmo/dependencylock/maven/json/JsonConstants.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/json/JsonConstants.java
@@ -1,7 +1,7 @@
 package se.vandmo.dependencylock.maven.json;
 
 final class JsonConstants {
-  static final String USE_PROJECT_VERSION = "use-project-version";
+  static final String USE_PROJECT_VERSION = "${project.version}";
   static final String IGNORED = "ignored";
 
   private JsonConstants() {}

--- a/src/main/java/se/vandmo/dependencylock/maven/json/LockfileJson.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/json/LockfileJson.java
@@ -39,14 +39,18 @@ import se.vandmo.dependencylock.maven.Parent;
 import se.vandmo.dependencylock.maven.Parents;
 import se.vandmo.dependencylock.maven.Plugin;
 import se.vandmo.dependencylock.maven.Plugins;
+import se.vandmo.dependencylock.maven.versions.VersionConstraint;
+import se.vandmo.dependencylock.maven.versions.VersionConstraints;
 
 public final class LockfileJson implements Lockfile {
 
   private static final String V2 = "2";
   private final LockFileAccessor dependenciesLockFile;
+  private final VersionConstraintJsonSerializer versionConstraintJsonSerializer;
 
   private LockfileJson(LockFileAccessor dependenciesLockFile) {
     this.dependenciesLockFile = dependenciesLockFile;
+    this.versionConstraintJsonSerializer = new VersionConstraintJsonSerializer();
   }
 
   public static LockfileJson from(LockFileAccessor dependenciesLockFile) {
@@ -123,9 +127,20 @@ public final class LockfileJson implements Lockfile {
                 .classifier(possiblyGetStringValue(json, "classifier"))
                 .type(possiblyGetStringValue(json, "type"))
                 .build())
-        .version(getNonBlankStringValue(json, "version"))
+        .version(parseVersionConstraint(getNonBlankStringValue(json, "version")))
         .integrity(getNonBlankStringValue(json, "integrity"))
         .build();
+  }
+
+  private static VersionConstraint parseVersionConstraint(String versionConstraint) {
+    switch (versionConstraint) {
+      case JsonConstants.USE_PROJECT_VERSION:
+        return VersionConstraints.useProjectVersion();
+      case JsonConstants.IGNORED:
+        return VersionConstraints.ignoreVersion();
+      default:
+        return VersionConstraints.version(versionConstraint);
+    }
   }
 
   private static Parents loadParentsFromJson(JsonNode json) {
@@ -278,7 +293,7 @@ public final class LockfileJson implements Lockfile {
     final ArtifactIdentifier artifactIdentifier = artifact.identifier;
     output.put("groupId", artifactIdentifier.groupId);
     output.put("artifactId", artifactIdentifier.artifactId);
-    output.put("version", artifact.version);
+    output.set("version", artifact.version.accept(this.versionConstraintJsonSerializer, factory));
     artifactIdentifier.classifier.ifPresent(
         actualClassifier -> output.put("classifier", actualClassifier));
     output.put("type", artifactIdentifier.type);
@@ -353,7 +368,9 @@ public final class LockfileJson implements Lockfile {
       final ArtifactIdentifier artifactIdentifier = lockedParent.getArtifactIdentifier();
       json.put("groupId", artifactIdentifier.groupId);
       json.put("artifactId", artifactIdentifier.artifactId);
-      json.put("version", lockedParent.getVersion());
+      json.set(
+          "version",
+          lockedParent.getVersion().accept(versionConstraintJsonSerializer, jsonNodeFactory));
       json.put("type", artifactIdentifier.type);
       json.put("integrity", lockedParent.getIntegrityForLockFile());
       jsonParentsArray.add(json);

--- a/src/main/java/se/vandmo/dependencylock/maven/json/VersionConstraintJsonSerializer.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/json/VersionConstraintJsonSerializer.java
@@ -1,0 +1,28 @@
+package se.vandmo.dependencylock.maven.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import se.vandmo.dependencylock.maven.versions.VersionConstraintVisitor;
+
+final class VersionConstraintJsonSerializer
+    implements VersionConstraintVisitor<JsonNode, JsonNodeFactory> {
+
+  VersionConstraintJsonSerializer() {
+    super();
+  }
+
+  @Override
+  public JsonNode onVersion(String version, JsonNodeFactory context) {
+    return context.textNode(version);
+  }
+
+  @Override
+  public JsonNode onProjectVersion(JsonNodeFactory context) {
+    return context.textNode(JsonConstants.USE_PROJECT_VERSION);
+  }
+
+  @Override
+  public JsonNode onIgnoreVersion(JsonNodeFactory context) {
+    return context.textNode(JsonConstants.IGNORED);
+  }
+}

--- a/src/main/java/se/vandmo/dependencylock/maven/mojos/LockMojo.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/mojos/LockMojo.java
@@ -179,5 +179,4 @@ public final class LockMojo extends AbstractDependencyLockMojo {
     resultingArtifact.setOptional(dependency.isOptional());
     return resultingArtifact;
   }
-
 }

--- a/src/main/java/se/vandmo/dependencylock/maven/pom/PomLockFile.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/pom/PomLockFile.java
@@ -29,6 +29,8 @@ import se.vandmo.dependencylock.maven.Artifacts;
 import se.vandmo.dependencylock.maven.Dependency;
 import se.vandmo.dependencylock.maven.Extension;
 import se.vandmo.dependencylock.maven.Plugin;
+import se.vandmo.dependencylock.maven.versions.VersionConstraint;
+import se.vandmo.dependencylock.maven.versions.VersionConstraints;
 
 public final class PomLockFile {
 
@@ -286,7 +288,7 @@ public final class PomLockFile {
       throws XMLStreamException {
     String groupId = null;
     String artifactId = null;
-    String version = null;
+    VersionConstraint version = null;
     String type = null;
     String scope = null;
     String classifier = null;
@@ -302,7 +304,7 @@ public final class PomLockFile {
         } else if (name.equals(ARTIFACT_ID)) {
           artifactId = readSingleTextElement(rdr);
         } else if (name.equals(VERSION)) {
-          version = readSingleTextElement(rdr);
+          version = readVersionConstraint(rdr);
         } else if (name.equals(TYPE)) {
           type = readSingleTextElement(rdr);
         } else if (name.equals(SCOPE)) {
@@ -374,7 +376,7 @@ public final class PomLockFile {
   private static Artifact fromPluginDependency(XMLEventReader2 rdr) throws XMLStreamException {
     String groupId = null;
     String artifactId = null;
-    String version = null;
+    VersionConstraint version = null;
     String type = null;
     String classifier = null;
     String integrity = null;
@@ -387,7 +389,7 @@ public final class PomLockFile {
         } else if (name.equals(ARTIFACT_ID)) {
           artifactId = readSingleTextElement(rdr);
         } else if (name.equals(VERSION)) {
-          version = readSingleTextElement(rdr);
+          version = readVersionConstraint(rdr);
         } else if (name.equals(TYPE)) {
           type = readSingleTextElement(rdr);
         } else if (name.equals(CLASSIFIER)) {
@@ -427,7 +429,7 @@ public final class PomLockFile {
   private static Extension fromExtension(XMLEventReader2 rdr) throws XMLStreamException {
     String groupId = null;
     String artifactId = null;
-    String version = null;
+    VersionConstraint version = null;
     String integrity = null;
     while (rdr.hasNextEvent()) {
       XMLEvent event = rdr.nextEvent();
@@ -438,7 +440,7 @@ public final class PomLockFile {
         } else if (name.equals(ARTIFACT_ID)) {
           artifactId = readSingleTextElement(rdr);
         } else if (name.equals(VERSION)) {
-          version = readSingleTextElement(rdr);
+          version = readVersionConstraint(rdr);
         } else if (name.equals(INTEGRITY)) {
           integrity = readSingleTextElement(rdr);
         } else {
@@ -465,7 +467,11 @@ public final class PomLockFile {
   }
 
   private static void validateArtifactWithIntegrity(
-      String groupId, String artifactId, String version, String integrity, XMLEvent event) {
+      String groupId,
+      String artifactId,
+      VersionConstraint version,
+      String integrity,
+      XMLEvent event) {
     validateArtifact(groupId, artifactId, version, event);
     if (integrity == null) {
       throw new InvalidPomLockFile("Missing integrity", event.getLocation());
@@ -473,7 +479,7 @@ public final class PomLockFile {
   }
 
   private static void validateArtifact(
-      String groupId, String artifactId, String version, XMLEvent event) {
+      String groupId, String artifactId, VersionConstraint version, XMLEvent event) {
     if (groupId == null) {
       throw new InvalidPomLockFile("Missing groupId", event.getLocation());
     }
@@ -488,7 +494,7 @@ public final class PomLockFile {
   private static Plugin fromPlugin(XMLEventReader2 rdr) throws XMLStreamException {
     String groupId = null;
     String artifactId = null;
-    String version = null;
+    VersionConstraint version = null;
     String integrity = null;
     List<Artifact> artifacts = emptyList();
     while (rdr.hasNextEvent()) {
@@ -500,7 +506,7 @@ public final class PomLockFile {
         } else if (name.equals(ARTIFACT_ID)) {
           artifactId = readSingleTextElement(rdr);
         } else if (name.equals(VERSION)) {
-          version = readSingleTextElement(rdr);
+          version = readVersionConstraint(rdr);
         } else if (name.equals(INTEGRITY)) {
           integrity = readSingleTextElement(rdr);
         } else if (name.equals(DEPENDENCIES)) {
@@ -527,6 +533,18 @@ public final class PomLockFile {
       }
     }
     throw new InvalidPomLockFile("Ended prematurely");
+  }
+
+  private static VersionConstraint readVersionConstraint(XMLEventReader2 reader)
+      throws XMLStreamException {
+    String versionConstraint = readSingleTextElement(reader);
+    if ("${project.version}".equals(versionConstraint)) {
+      return VersionConstraints.useProjectVersion();
+    } else if ("ignored".equals(versionConstraint)) {
+      return VersionConstraints.ignoreVersion();
+    } else {
+      return VersionConstraints.version(versionConstraint);
+    }
   }
 
   private static String readSingleTextElement(XMLEventReader2 reader) throws XMLStreamException {

--- a/src/main/java/se/vandmo/dependencylock/maven/versions/IgnoreVersionConstraint.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/versions/IgnoreVersionConstraint.java
@@ -1,0 +1,22 @@
+package se.vandmo.dependencylock.maven.versions;
+
+final class IgnoreVersionConstraint extends VersionConstraint {
+  IgnoreVersionConstraint() {
+    super();
+  }
+
+  @Override
+  public <T, C> T accept(VersionConstraintVisitor<T, C> visitor, C context) {
+    return visitor.onIgnoreVersion(context);
+  }
+
+  @Override
+  public boolean compliantWith(VersionConstraint other, VersionConstraintContext context) {
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "ignored";
+  }
+}

--- a/src/main/java/se/vandmo/dependencylock/maven/versions/UseProjectVersionConstraint.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/versions/UseProjectVersionConstraint.java
@@ -1,0 +1,56 @@
+package se.vandmo.dependencylock.maven.versions;
+
+final class UseProjectVersionConstraint extends VersionConstraint {
+
+  UseProjectVersionConstraint() {
+    super();
+  }
+
+  @Override
+  public <T, C> T accept(VersionConstraintVisitor<T, C> visitor, C context) {
+    return visitor.onProjectVersion(context);
+  }
+
+  /**
+   * Returns <code>true</code> if the given constraint ignores versions, accepts project versions or
+   * is strict about versions and accepts the given context project version.
+   *
+   * @param other the constraint against which this constraint is to be compared.
+   * @param context the context in which the comparison is to be performed.
+   * @return true if, and only if, the given constraint accepts project versions, all versions, or
+   *     the given context project version.
+   */
+  @Override
+  public boolean compliantWith(VersionConstraint other, VersionConstraintContext context) {
+    return other.accept(ProjectVersionCompliancyChecker.INSTANCE, context).booleanValue();
+  }
+
+  @Override
+  public String toString() {
+    return "project-version";
+  }
+
+  private static final class ProjectVersionCompliancyChecker
+      implements VersionConstraintVisitor<Boolean, VersionConstraintContext> {
+    static final ProjectVersionCompliancyChecker INSTANCE = new ProjectVersionCompliancyChecker();
+
+    private ProjectVersionCompliancyChecker() {
+      super();
+    }
+
+    @Override
+    public Boolean onVersion(String version, VersionConstraintContext context) {
+      return version.equals(context.getProjectVersion());
+    }
+
+    @Override
+    public Boolean onProjectVersion(VersionConstraintContext context) {
+      return Boolean.TRUE;
+    }
+
+    @Override
+    public Boolean onIgnoreVersion(VersionConstraintContext context) {
+      return Boolean.TRUE;
+    }
+  }
+}

--- a/src/main/java/se/vandmo/dependencylock/maven/versions/UseProjectVersionConstraint.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/versions/UseProjectVersionConstraint.java
@@ -27,7 +27,7 @@ final class UseProjectVersionConstraint extends VersionConstraint {
 
   @Override
   public String toString() {
-    return "project-version";
+    return "${project.version}";
   }
 
   private static final class ProjectVersionCompliancyChecker

--- a/src/main/java/se/vandmo/dependencylock/maven/versions/VersionConstraint.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/versions/VersionConstraint.java
@@ -1,0 +1,34 @@
+package se.vandmo.dependencylock.maven.versions;
+
+/**
+ * Instances of this class shall be able to represent the constraint on a given artifact's version.
+ */
+public abstract class VersionConstraint {
+
+  VersionConstraint() {
+    super();
+  }
+
+  /**
+   * Have the specified visitor parameter visit this instance with the given context parameter.
+   *
+   * @param visitor what should be processing this instance
+   * @param context the context for this instance's processing
+   * @return the result of the given visitor's visting of this instance
+   * @param <T> the type of data returned by the specified visitor parameter
+   * @param <C> the type of context supported by the specified visitor parameter
+   * @throws NullPointerException if the specified visitor parameter is <code>null</code>
+   */
+  public abstract <T, C> T accept(VersionConstraintVisitor<T, C> visitor, C context);
+
+  /**
+   * Returns <code>true</code> if this constraint is compliant with the given constraint.
+   *
+   * @param other the constraint against which this constraint is to be compared.
+   * @param context the context in which the comparison is to be performed.
+   * @return true if, and only if, the given constraint could be satisfied by this constraint.
+   */
+  public abstract boolean compliantWith(VersionConstraint other, VersionConstraintContext context);
+
+  public abstract String toString();
+}

--- a/src/main/java/se/vandmo/dependencylock/maven/versions/VersionConstraintContext.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/versions/VersionConstraintContext.java
@@ -1,0 +1,9 @@
+package se.vandmo.dependencylock.maven.versions;
+
+/**
+ * Implementations of this interface shall provide with information which can be used in version
+ * constraint evaluation.
+ */
+public interface VersionConstraintContext {
+  String getProjectVersion();
+}

--- a/src/main/java/se/vandmo/dependencylock/maven/versions/VersionConstraintImpl.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/versions/VersionConstraintImpl.java
@@ -1,0 +1,54 @@
+package se.vandmo.dependencylock.maven.versions;
+
+import java.util.Objects;
+
+final class VersionConstraintImpl extends VersionConstraint
+    implements VersionConstraintVisitor<Boolean, VersionConstraintContext> {
+  private final String version;
+
+  VersionConstraintImpl(String version) {
+    this.version = version;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof VersionConstraintImpl)) return false;
+    VersionConstraintImpl that = (VersionConstraintImpl) o;
+    return Objects.equals(version, that.version);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(version);
+  }
+
+  @Override
+  public <T, C> T accept(VersionConstraintVisitor<T, C> visitor, C context) {
+    return visitor.onVersion(version, context);
+  }
+
+  @Override
+  public Boolean onVersion(String version, VersionConstraintContext context) {
+    return this.version.equals(version);
+  }
+
+  @Override
+  public Boolean onProjectVersion(VersionConstraintContext context) {
+    return this.version.equals(context.getProjectVersion());
+  }
+
+  @Override
+  public Boolean onIgnoreVersion(VersionConstraintContext context) {
+    return Boolean.TRUE;
+  }
+
+  @Override
+  public boolean compliantWith(VersionConstraint other, VersionConstraintContext context) {
+    return other.accept(this, context).booleanValue();
+  }
+
+  @Override
+  public String toString() {
+    return this.version;
+  }
+}

--- a/src/main/java/se/vandmo/dependencylock/maven/versions/VersionConstraintVisitor.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/versions/VersionConstraintVisitor.java
@@ -1,0 +1,12 @@
+package se.vandmo.dependencylock.maven.versions;
+
+/**
+ * @author Antoine Malliarakis
+ */
+public interface VersionConstraintVisitor<T, C> {
+  T onVersion(String version, C context);
+
+  T onProjectVersion(C context);
+
+  T onIgnoreVersion(C context);
+}

--- a/src/main/java/se/vandmo/dependencylock/maven/versions/VersionConstraints.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/versions/VersionConstraints.java
@@ -1,0 +1,25 @@
+package se.vandmo.dependencylock.maven.versions;
+
+import java.util.Objects;
+
+/**
+ * @author Antoine Malliarakis
+ */
+public final class VersionConstraints {
+  private VersionConstraints() {}
+
+  private static final VersionConstraint USE_PROJECT_VERSION = new UseProjectVersionConstraint();
+  private static final VersionConstraint IGNORE_VERSION = new IgnoreVersionConstraint();
+
+  public static VersionConstraint useProjectVersion() {
+    return USE_PROJECT_VERSION;
+  }
+
+  public static VersionConstraint ignoreVersion() {
+    return IGNORE_VERSION;
+  }
+
+  public static VersionConstraint version(String version) {
+    return new VersionConstraintImpl(Objects.requireNonNull(version));
+  }
+}

--- a/src/test/java/ArtifactTests.java
+++ b/src/test/java/ArtifactTests.java
@@ -3,6 +3,7 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import se.vandmo.dependencylock.maven.Artifact;
 import se.vandmo.dependencylock.maven.ArtifactIdentifier;
+import se.vandmo.dependencylock.maven.versions.VersionConstraint;
 
 public final class ArtifactTests {
 
@@ -18,7 +19,12 @@ public final class ArtifactTests {
 
   @Test(expected = NullPointerException.class)
   public void builder_version_null() {
-    Artifact.builder().artifactIdentifier(anArtifactIdentifier()).version(null);
+    Artifact.builder().artifactIdentifier(anArtifactIdentifier()).version((String) null);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void builder_version_constraint_null() {
+    Artifact.builder().artifactIdentifier(anArtifactIdentifier()).version((VersionConstraint) null);
   }
 
   @Test(expected = NullPointerException.class)

--- a/src/test/java/DependencyTests.java
+++ b/src/test/java/DependencyTests.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import se.vandmo.dependencylock.maven.ArtifactIdentifier;
 import se.vandmo.dependencylock.maven.Dependency;
 import se.vandmo.dependencylock.maven.Integrity;
+import se.vandmo.dependencylock.maven.versions.VersionConstraint;
 
 public final class DependencyTests {
 
@@ -19,7 +20,14 @@ public final class DependencyTests {
 
   @Test(expected = NullPointerException.class)
   public void builder_version_null() {
-    Dependency.builder().artifactIdentifier(anArtifactIdentifier()).version(null);
+    Dependency.builder().artifactIdentifier(anArtifactIdentifier()).version((String) null);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void builder_version_null_versionConstraint() {
+    Dependency.builder()
+        .artifactIdentifier(anArtifactIdentifier())
+        .version((VersionConstraint) null);
   }
 
   @Test(expected = NullPointerException.class)


### PR DESCRIPTION
When the constraints on the dependency set's version is only "use-project-version", we are now replacing it explicitly as `${project.version}` when `markIgnoredAsIgnored` is `true`. Making it "repeatable".

Fixes #113 

As a bonus it also fixes an integration test which wasn't appropriately checking expectations

### Notes

There were three possibilities here:

1. Create a new file version (to be on the safe side with regards to being able to read version appropriately when `check` mojo configuration doesn't use the same setting) for both json and pom files
2. Ignore this potential issue and identify this as a caveat
3. Add an extra parameter in addition to the `markIgnoredAsIgnored` which would make it more explicit how it's persisted

I went for the second approach with the following rationale:

1. When the "use-project-version" is selected this information is ignored when running the `check` mojo
2. `${project.version}` is the common way to specify this in POM raw model (and would systematically be resolved at runtime to the actual project version)
