### PR TITLE
fix: remove empty profiles nodes

### DIFF
--- a/src/it/json/lock-build-with-extension/3.6.3/expected/dependencies-lock.json
+++ b/src/it/json/lock-build-with-extension/3.6.3/expected/dependencies-lock.json
@@ -1,5 +1,5 @@
 {
-  "version" : "3",
+  "version" : "2",
   "artifacts" : {
     "antlr:antlr:jar:2.7.2" : {
       "groupId" : "antlr",
@@ -1295,6 +1295,5 @@
     "artifact" : "se.vandmo.testing:leaf:jar:1.0",
     "scope" : "compile",
     "optional" : false
-  } ],
-  "profiles" : [ ]
+  } ]
 }

--- a/src/it/json/lock-build-with-extension/4.0.0-rc-5/expected/dependencies-lock.json
+++ b/src/it/json/lock-build-with-extension/4.0.0-rc-5/expected/dependencies-lock.json
@@ -1,5 +1,5 @@
 {
-  "version" : "3",
+  "version" : "2",
   "artifacts" : {
     "com.fasterxml.jackson.core:jackson-annotations:jar:2.18.3" : {
       "groupId" : "com.fasterxml.jackson.core",
@@ -1028,6 +1028,5 @@
     "artifact" : "se.vandmo.testing:leaf:jar:1.0",
     "scope" : "compile",
     "optional" : false
-  } ],
-  "profiles" : [ ]
+  } ]
 }

--- a/src/it/json/lock-build-with-extension/expected/dependencies-lock.json
+++ b/src/it/json/lock-build-with-extension/expected/dependencies-lock.json
@@ -1,5 +1,5 @@
 {
-  "version" : "3",
+  "version" : "2",
   "artifacts" : {
     "aopalliance:aopalliance:jar:1.0" : {
       "groupId" : "aopalliance",
@@ -1358,6 +1358,5 @@
     "artifact" : "se.vandmo.testing:leaf:jar:1.0",
     "scope" : "compile",
     "optional" : false
-  } ],
-  "profiles" : [ ]
+  } ]
 }

--- a/src/it/json/lock-build-with-local-parent/3.6.3/expected/dependencies-lock.json
+++ b/src/it/json/lock-build-with-local-parent/3.6.3/expected/dependencies-lock.json
@@ -1,5 +1,5 @@
 {
-  "version" : "3",
+  "version" : "2",
   "artifacts" : {
     "antlr:antlr:jar:2.7.2" : {
       "groupId" : "antlr",
@@ -1292,6 +1292,5 @@
     "artifact" : "se.vandmo.testing:leaf:jar:1.0",
     "scope" : "compile",
     "optional" : false
-  } ],
-  "profiles" : [ ]
+  } ]
 }

--- a/src/it/json/lock-build-with-local-parent/4.0.0-rc-5/expected/dependencies-lock.json
+++ b/src/it/json/lock-build-with-local-parent/4.0.0-rc-5/expected/dependencies-lock.json
@@ -1,5 +1,5 @@
 {
-  "version" : "3",
+  "version" : "2",
   "artifacts" : {
     "com.fasterxml.jackson.core:jackson-annotations:jar:2.18.3" : {
       "groupId" : "com.fasterxml.jackson.core",
@@ -1025,6 +1025,5 @@
     "artifact" : "se.vandmo.testing:leaf:jar:1.0",
     "scope" : "compile",
     "optional" : false
-  } ],
-  "profiles" : [ ]
+  } ]
 }

--- a/src/it/json/lock-build-with-local-parent/expected/dependencies-lock.json
+++ b/src/it/json/lock-build-with-local-parent/expected/dependencies-lock.json
@@ -1,5 +1,5 @@
 {
-  "version" : "3",
+  "version" : "2",
   "artifacts" : {
     "aopalliance:aopalliance:jar:1.0" : {
       "groupId" : "aopalliance",
@@ -1355,6 +1355,5 @@
     "artifact" : "se.vandmo.testing:leaf:jar:1.0",
     "scope" : "compile",
     "optional" : false
-  } ],
-  "profiles" : [ ]
+  } ]
 }

--- a/src/it/json/lock-build-with-parent/3.6.3/expected/dependencies-lock.json
+++ b/src/it/json/lock-build-with-parent/3.6.3/expected/dependencies-lock.json
@@ -1,5 +1,5 @@
 {
-  "version" : "3",
+  "version" : "2",
   "artifacts" : {
     "antlr:antlr:jar:2.7.2" : {
       "groupId" : "antlr",
@@ -1298,6 +1298,5 @@
     "artifact" : "se.vandmo.testing:leaf:jar:1.0",
     "scope" : "compile",
     "optional" : false
-  } ],
-  "profiles" : [ ]
+  } ]
 }

--- a/src/it/json/lock-build-with-parent/4.0.0-rc-5/expected/dependencies-lock.json
+++ b/src/it/json/lock-build-with-parent/4.0.0-rc-5/expected/dependencies-lock.json
@@ -1,5 +1,5 @@
 {
-  "version" : "3",
+  "version" : "2",
   "artifacts" : {
     "com.fasterxml.jackson.core:jackson-annotations:jar:2.18.3" : {
       "groupId" : "com.fasterxml.jackson.core",
@@ -1031,6 +1031,5 @@
     "artifact" : "se.vandmo.testing:leaf:jar:1.0",
     "scope" : "compile",
     "optional" : false
-  } ],
-  "profiles" : [ ]
+  } ]
 }

--- a/src/it/json/lock-build-with-parent/expected/dependencies-lock.json
+++ b/src/it/json/lock-build-with-parent/expected/dependencies-lock.json
@@ -1,5 +1,5 @@
 {
-  "version" : "3",
+  "version" : "2",
   "artifacts" : {
     "aopalliance:aopalliance:jar:1.0" : {
       "groupId" : "aopalliance",
@@ -1361,6 +1361,5 @@
     "artifact" : "se.vandmo.testing:leaf:jar:1.0",
     "scope" : "compile",
     "optional" : false
-  } ],
-  "profiles" : [ ]
+  } ]
 }

--- a/src/it/json/lock-build/3.6.3/expected/dependencies-lock.json
+++ b/src/it/json/lock-build/3.6.3/expected/dependencies-lock.json
@@ -1,5 +1,5 @@
 {
-  "version" : "3",
+  "version" : "2",
   "artifacts" : {
     "antlr:antlr:jar:2.7.2" : {
       "groupId" : "antlr",
@@ -1286,6 +1286,5 @@
     "artifact" : "se.vandmo.testing:leaf:jar:1.0",
     "scope" : "compile",
     "optional" : false
-  } ],
-  "profiles" : [ ]
+  } ]
 }

--- a/src/it/json/lock-build/4.0.0-rc-5/expected/dependencies-lock.json
+++ b/src/it/json/lock-build/4.0.0-rc-5/expected/dependencies-lock.json
@@ -1,5 +1,5 @@
 {
-  "version" : "3",
+  "version" : "2",
   "artifacts" : {
     "com.fasterxml.jackson.core:jackson-annotations:jar:2.18.3" : {
       "groupId" : "com.fasterxml.jackson.core",
@@ -1019,6 +1019,5 @@
     "artifact" : "se.vandmo.testing:leaf:jar:1.0",
     "scope" : "compile",
     "optional" : false
-  } ],
-  "profiles" : [ ]
+  } ]
 }

--- a/src/it/json/lock-build/expected/dependencies-lock.json
+++ b/src/it/json/lock-build/expected/dependencies-lock.json
@@ -1,5 +1,5 @@
 {
-  "version" : "3",
+  "version" : "2",
   "artifacts" : {
     "aopalliance:aopalliance:jar:1.0" : {
       "groupId" : "aopalliance",
@@ -1349,6 +1349,5 @@
     "artifact" : "se.vandmo.testing:leaf:jar:1.0",
     "scope" : "compile",
     "optional" : false
-  } ],
-  "profiles" : [ ]
+  } ]
 }

--- a/src/main/java/se/vandmo/dependencylock/maven/json/DependenciesLockFileJson.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/json/DependenciesLockFileJson.java
@@ -17,7 +17,6 @@ import se.vandmo.dependencylock.maven.LockFileAccessor;
 import se.vandmo.dependencylock.maven.ProfiledDependencies;
 
 public final class DependenciesLockFileJson extends WithJsonHelper {
-  private static final String V3 = "3";
 
   private final LockFileAccessor dependenciesLockFile;
 
@@ -41,12 +40,19 @@ public final class DependenciesLockFileJson extends WithJsonHelper {
   public void write(ProfiledDependencies dependencies) {
     JsonNodeFactory jsonNodeFactory = JsonNodeFactory.instance;
     ObjectNode json = jsonNodeFactory.objectNode();
-    json.put("version", V3);
+    final JsonNode profilesJson = buildProfilesJson(dependencies.profileEntries(), jsonNodeFactory);
+    if (profilesJson.isEmpty()) {
+      json.put("version", V2);
+    } else {
+      json.put("version", V3);
+    }
     json.set("artifacts", buildArtifactsJson(dependencies.artifacts(), jsonNodeFactory));
     json.set(
         "dependencies",
         buildDependenciesJson(dependencies.getSharedDependencies(), jsonNodeFactory));
-    json.set("profiles", buildProfilesJson(dependencies.profileEntries(), jsonNodeFactory));
+    if (!profilesJson.isEmpty()) {
+      json.set("profiles", profilesJson);
+    }
     try (Writer writer = dependenciesLockFile.writer()) {
       writeJson(writer, json);
     } catch (IOException e) {

--- a/src/main/java/se/vandmo/dependencylock/maven/json/LockfileJson.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/json/LockfileJson.java
@@ -44,9 +44,6 @@ import se.vandmo.dependencylock.maven.ProfileEntry;
 import se.vandmo.dependencylock.maven.ProfiledDependencies;
 
 public final class LockfileJson extends WithJsonHelper implements Lockfile {
-
-  private static final String V2 = "2";
-  private static final String V3 = "3";
   private final LockFileAccessor dependenciesLockFile;
 
   private LockfileJson(LockFileAccessor dependenciesLockFile) {
@@ -265,7 +262,13 @@ public final class LockfileJson extends WithJsonHelper implements Lockfile {
 
   private JsonNode write(LockedProject contents, JsonNodeFactory jsonNodeFactory) {
     ObjectNode json = jsonNodeFactory.objectNode();
-    json.put("version", V3);
+    final JsonNode profilesNode =
+        buildProfilesJson(contents.dependencies.profileEntries(), jsonNodeFactory);
+    if (profilesNode.isEmpty()) {
+      json.put("version", V2);
+    } else {
+      json.put("version", V3);
+    }
     json.set("artifacts", buildArtifactsJson(collectArtifacts(contents), jsonNodeFactory));
     contents.parents.ifPresent(parents -> json.set("parents", toJson(parents, jsonNodeFactory)));
     contents.plugins.ifPresent(plugins -> json.set("plugins", toJson(plugins, jsonNodeFactory)));
@@ -274,8 +277,9 @@ public final class LockfileJson extends WithJsonHelper implements Lockfile {
     json.set(
         "dependencies",
         buildDependenciesJson(contents.dependencies.getSharedDependencies(), jsonNodeFactory));
-    json.set(
-        "profiles", buildProfilesJson(contents.dependencies.profileEntries(), jsonNodeFactory));
+    if (!profilesNode.isEmpty()) {
+      json.set("profiles", profilesNode);
+    }
     return json;
   }
 

--- a/src/main/java/se/vandmo/dependencylock/maven/json/WithJsonHelper.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/json/WithJsonHelper.java
@@ -23,6 +23,9 @@ import se.vandmo.dependencylock.maven.versions.VersionConstraint;
 import se.vandmo.dependencylock.maven.versions.VersionConstraints;
 
 class WithJsonHelper {
+  static final String V3 = "3";
+  static final String V2 = "2";
+
   final VersionConstraintJsonSerializer versionConstraintJsonSerializer;
 
   WithJsonHelper() {


### PR DESCRIPTION
Cleanup following feedback from #129 : remove profiles entry if empty (and keep version to remain as backward compatible as possible)