### PR TITLE
fix: correct os.name property emulation used for profile locking

### DIFF
--- a/src/main/java/se/vandmo/dependencylock/maven/ProfileUtils.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/ProfileUtils.java
@@ -94,7 +94,7 @@ public final class ProfileUtils {
         throw new MojoExecutionException("Negated os name activation clauses are not supported");
       }
       if (alreadyEmulatedOsName == null) {
-        emulatedValues.put("os.name", "not-" + targetOsName);
+        emulatedValues.put("os.name", targetOsName);
       } else if (!targetOsName.equals(alreadyEmulatedOsName)) {
         throw new MojoExecutionException(
             "Found conflicting os name clause ("

--- a/src/test/java/se/vandmo/dependencylock/maven/ProfileUtilsTest.java
+++ b/src/test/java/se/vandmo/dependencylock/maven/ProfileUtilsTest.java
@@ -35,9 +35,19 @@ public class ProfileUtilsTest {
     Mockito.doReturn("aarch-x64").when(mockActivationOS).getArch();
     Mockito.doReturn("mac").when(mockActivationOS).getFamily();
 
-    Assert.assertThrows(
-        "",
-        MojoExecutionException.class,
-        () -> ProfileUtils.emulateSystemProperties(mockActivationOS));
+    Throwable caughtException = null;
+    try {
+      ProfileUtils.emulateSystemProperties(mockActivationOS);
+    } catch (MojoExecutionException e) {
+      caughtException = e;
+    }
+    Assert.assertNotNull(
+        "An error should have been raised since os family was conflicting with os name.",
+        caughtException);
+    Assert.assertEquals(
+        "Unexpected exception message",
+        "Found conflicting os name clause (linux) which is not compatible with existing family"
+            + " (darwin)",
+        caughtException.getMessage());
   }
 }

--- a/src/test/java/se/vandmo/dependencylock/maven/ProfileUtilsTest.java
+++ b/src/test/java/se/vandmo/dependencylock/maven/ProfileUtilsTest.java
@@ -1,0 +1,43 @@
+package se.vandmo.dependencylock.maven;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import se.vandmo.dependencylock.maven.mojos.model.IActivationOS;
+
+public class ProfileUtilsTest {
+
+  @Test
+  public void emulatedProperties_IActivationOS_appropriatelySupportsOsName()
+      throws MojoExecutionException {
+    IActivationOS mockActivationOS = Mockito.mock(IActivationOS.class);
+    Mockito.doReturn("linux").when(mockActivationOS).getName();
+    Mockito.doReturn("aarch-x64").when(mockActivationOS).getArch();
+
+    Map<String, String> expected = new HashMap<>();
+    expected.put("os.name", "linux");
+    expected.put("os.arch", "aarch-x64");
+
+    Map<String, String> emulatedProperties = ProfileUtils.emulateSystemProperties(mockActivationOS);
+
+    assertEquals("Unexpected emulated properties generated", expected, emulatedProperties);
+  }
+
+  @Test
+  public void emulatedProperties_IActivationOS_appropriatelyFailsOnConflict() {
+    IActivationOS mockActivationOS = Mockito.mock(IActivationOS.class);
+    Mockito.doReturn("linux").when(mockActivationOS).getName();
+    Mockito.doReturn("aarch-x64").when(mockActivationOS).getArch();
+    Mockito.doReturn("mac").when(mockActivationOS).getFamily();
+
+    Assert.assertThrows(
+        "",
+        MojoExecutionException.class,
+        () -> ProfileUtils.emulateSystemProperties(mockActivationOS));
+  }
+}


### PR DESCRIPTION
It turns out the system properties emulation process was blatantly broken when trying to emulate system properties.

Added corresponding unit test to make sure it no longer occurs