### PR TITLE
fix: remove empty profiles from lock file generations

### DIFF
--- a/src/main/java/se/vandmo/dependencylock/maven/ProfileEntry.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/ProfileEntry.java
@@ -21,6 +21,10 @@ public final class ProfileEntry {
     return dependencies;
   }
 
+  public boolean isEmpty() {
+    return getDependencies().size() == 0;
+  }
+
   public Profile getProfile() {
     return profile;
   }

--- a/src/main/java/se/vandmo/dependencylock/maven/json/WithJsonHelper.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/json/WithJsonHelper.java
@@ -110,6 +110,7 @@ class WithJsonHelper {
   JsonNode buildProfilesJson(Stream<ProfileEntry> profiles, JsonNodeFactory jsonNodeFactory) {
     ArrayNode result = jsonNodeFactory.arrayNode();
     profiles
+        .filter(entry -> !entry.isEmpty())
         .sorted(Comparator.comparing(entry -> entry.getProfile().getId()))
         .forEach(
             profile -> {

--- a/src/main/java/se/vandmo/dependencylock/maven/pom/DependenciesLockFilePom.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/pom/DependenciesLockFilePom.java
@@ -1,27 +1,17 @@
 package se.vandmo.dependencylock.maven.pom;
 
-import static freemarker.template.TemplateExceptionHandler.RETHROW_HANDLER;
 import static java.util.Objects.requireNonNull;
 
 import freemarker.template.Configuration;
-import freemarker.template.DefaultObjectWrapperBuilder;
-import freemarker.template.ObjectWrapper;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
-import freemarker.template.Version;
 import java.io.IOException;
 import java.io.Writer;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Collectors;
 import se.vandmo.dependencylock.maven.LockFileAccessor;
 import se.vandmo.dependencylock.maven.PomMinimums;
 import se.vandmo.dependencylock.maven.ProfiledDependencies;
 
-public final class DependenciesLockFilePom {
-
-  private static final Version VERSION = Configuration.VERSION_2_3_31;
+public final class DependenciesLockFilePom extends WithLockFilePom {
 
   private final LockFileAccessor dependenciesLockFile;
   private final PomMinimums pomMinimums;
@@ -47,45 +37,5 @@ public final class DependenciesLockFilePom {
     } catch (IOException | TemplateException e) {
       throw new RuntimeException(e);
     }
-  }
-
-  private static Map<String, Object> makeDataModel(
-      PomMinimums pomMinimums, ProfiledDependencies projectDependencies) {
-    Map<String, Object> dataModel = new HashMap<>();
-    dataModel.put("pom", pomMinimums);
-    dataModel.put("dependencies", projectDependencies.getSharedDependencies());
-    dataModel.put(
-        "profiles",
-        projectDependencies
-            .profileEntries()
-            .sorted(Comparator.comparing(entry -> entry.getProfile().getId()))
-            .map(
-                entry -> {
-                  Map<String, Object> profile = new HashMap<>();
-                  profile.put("id", entry.getProfile().getId());
-                  profile.put("activation", entry.getProfile().getActivation());
-                  profile.put("dependencies", entry.getDependencies());
-                  return profile;
-                })
-            .collect(Collectors.toList()));
-    return dataModel;
-  }
-
-  private static Configuration createConfiguration() {
-    Configuration cfg = new Configuration(VERSION);
-    cfg.setClassForTemplateLoading(DependenciesLockFilePom.class, "");
-    cfg.setDefaultEncoding("UTF-8");
-    cfg.setTemplateExceptionHandler(RETHROW_HANDLER);
-    cfg.setLogTemplateExceptions(false);
-    cfg.setFallbackOnNullLoopVariable(false);
-    cfg.setObjectWrapper(getObjectWrapper());
-    return cfg;
-  }
-
-  private static ObjectWrapper getObjectWrapper() {
-    DefaultObjectWrapperBuilder builder = new DefaultObjectWrapperBuilder(VERSION);
-    builder.setExposeFields(true);
-    builder.setIterableSupport(true);
-    return builder.build();
   }
 }

--- a/src/main/java/se/vandmo/dependencylock/maven/pom/LockFilePom.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/pom/LockFilePom.java
@@ -1,24 +1,18 @@
 package se.vandmo.dependencylock.maven.pom;
 
-import static freemarker.template.TemplateExceptionHandler.RETHROW_HANDLER;
 import static java.lang.String.format;
 import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 import freemarker.template.Configuration;
-import freemarker.template.DefaultObjectWrapperBuilder;
-import freemarker.template.ObjectWrapper;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
-import freemarker.template.Version;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -34,9 +28,7 @@ import se.vandmo.dependencylock.maven.PomMinimums;
 import se.vandmo.dependencylock.maven.ProfileEntry;
 import se.vandmo.dependencylock.maven.ProfiledDependencies;
 
-public final class LockFilePom implements Lockfile {
-
-  private static final Version VERSION = Configuration.VERSION_2_3_31;
+public final class LockFilePom extends WithLockFilePom implements Lockfile {
 
   private final LockFileAccessor dependenciesLockFile;
   private final PomMinimums pomMinimums;
@@ -75,48 +67,12 @@ public final class LockFilePom implements Lockfile {
     }
   }
 
-  private static Map<String, Object> makeDataModel(
-      PomMinimums pomMinimums, LockedProject lockedProject) {
-    Map<String, Object> dataModel = new HashMap<>();
-    dataModel.put("pom", pomMinimums);
-    dataModel.put("dependencies", lockedProject.dependencies.getSharedDependencies());
+  private Map<String, Object> makeDataModel(PomMinimums pomMinimums, LockedProject lockedProject) {
+    Map<String, Object> dataModel = super.makeDataModel(pomMinimums, lockedProject.dependencies);
     lockedProject.parents.ifPresent(parents -> dataModel.put("parents", parents));
     lockedProject.plugins.ifPresent(plugins -> dataModel.put("plugins", plugins));
     lockedProject.extensions.ifPresent(extensions -> dataModel.put("extensions", extensions));
-    dataModel.put(
-        "profiles",
-        lockedProject
-            .dependencies
-            .profileEntries()
-            .sorted(Comparator.comparing(a -> a.getProfile().getId()))
-            .map(
-                entry -> {
-                  Map<String, Object> result = new HashMap<>();
-                  result.put("id", entry.getProfile().getId());
-                  result.put("activation", entry.getProfile().getActivation());
-                  result.put("dependencies", entry.getDependencies());
-                  return result;
-                })
-            .collect(toList()));
     return dataModel;
-  }
-
-  private static Configuration createConfiguration() {
-    Configuration cfg = new Configuration(VERSION);
-    cfg.setClassForTemplateLoading(LockFilePom.class, "");
-    cfg.setDefaultEncoding("UTF-8");
-    cfg.setTemplateExceptionHandler(RETHROW_HANDLER);
-    cfg.setLogTemplateExceptions(false);
-    cfg.setFallbackOnNullLoopVariable(false);
-    cfg.setObjectWrapper(getObjectWrapper());
-    return cfg;
-  }
-
-  private static ObjectWrapper getObjectWrapper() {
-    DefaultObjectWrapperBuilder builder = new DefaultObjectWrapperBuilder(VERSION);
-    builder.setExposeFields(true);
-    builder.setIterableSupport(true);
-    return builder.build();
   }
 
   @Override

--- a/src/main/java/se/vandmo/dependencylock/maven/pom/WithLockFilePom.java
+++ b/src/main/java/se/vandmo/dependencylock/maven/pom/WithLockFilePom.java
@@ -1,0 +1,60 @@
+package se.vandmo.dependencylock.maven.pom;
+
+import static freemarker.template.TemplateExceptionHandler.RETHROW_HANDLER;
+
+import freemarker.template.Configuration;
+import freemarker.template.DefaultObjectWrapperBuilder;
+import freemarker.template.ObjectWrapper;
+import freemarker.template.Version;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import se.vandmo.dependencylock.maven.PomMinimums;
+import se.vandmo.dependencylock.maven.ProfiledDependencies;
+
+class WithLockFilePom {
+
+  private static final Version VERSION = Configuration.VERSION_2_3_31;
+
+  final Configuration createConfiguration() {
+    Configuration cfg = new Configuration(VERSION);
+    cfg.setClassForTemplateLoading(WithLockFilePom.class, "");
+    cfg.setDefaultEncoding("UTF-8");
+    cfg.setTemplateExceptionHandler(RETHROW_HANDLER);
+    cfg.setLogTemplateExceptions(false);
+    cfg.setFallbackOnNullLoopVariable(false);
+    cfg.setObjectWrapper(getObjectWrapper());
+    return cfg;
+  }
+
+  private static ObjectWrapper getObjectWrapper() {
+    DefaultObjectWrapperBuilder builder = new DefaultObjectWrapperBuilder(VERSION);
+    builder.setExposeFields(true);
+    builder.setIterableSupport(true);
+    return builder.build();
+  }
+
+  final Map<String, Object> makeDataModel(
+      PomMinimums pomMinimums, ProfiledDependencies projectDependencies) {
+    Map<String, Object> dataModel = new HashMap<>();
+    dataModel.put("pom", pomMinimums);
+    dataModel.put("dependencies", projectDependencies.getSharedDependencies());
+    dataModel.put(
+        "profiles",
+        projectDependencies
+            .profileEntries()
+            .filter(entry -> !entry.isEmpty())
+            .sorted(Comparator.comparing(entry -> entry.getProfile().getId()))
+            .map(
+                entry -> {
+                  Map<String, Object> profile = new HashMap<>();
+                  profile.put("id", entry.getProfile().getId());
+                  profile.put("activation", entry.getProfile().getActivation());
+                  profile.put("dependencies", entry.getDependencies());
+                  return profile;
+                })
+            .collect(Collectors.toList()));
+    return dataModel;
+  }
+}

--- a/src/test/java/se/vandmo/dependencylock/maven/pom/WithLockFilePomTest.java
+++ b/src/test/java/se/vandmo/dependencylock/maven/pom/WithLockFilePomTest.java
@@ -1,0 +1,98 @@
+package se.vandmo.dependencylock.maven.pom;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.maven.project.MavenProject;
+import org.junit.Assert;
+import org.junit.Test;
+import se.vandmo.dependencylock.maven.ArtifactIdentifier;
+import se.vandmo.dependencylock.maven.Dependencies;
+import se.vandmo.dependencylock.maven.Dependency;
+import se.vandmo.dependencylock.maven.Integrity;
+import se.vandmo.dependencylock.maven.PomMinimums;
+import se.vandmo.dependencylock.maven.ProfileEntry;
+import se.vandmo.dependencylock.maven.ProfiledDependencies;
+import se.vandmo.dependencylock.maven.mojos.model.Profile;
+
+public class WithLockFilePomTest {
+
+  @Test
+  public void makeDataModel_ignores_empty_entries() {
+    Map<String, Object> dataModel =
+        new WithLockFilePom()
+            .makeDataModel(
+                getPomMinimums(),
+                new ProfiledDependencies(
+                    Dependencies.fromDependencies(Collections.emptyList()),
+                    Arrays.asList(
+                        new ProfileEntry(
+                            new Profile(),
+                            Dependencies.fromDependencies(Collections.emptyList())))));
+    Assert.assertEquals(Collections.emptyList(), dataModel.get("profiles"));
+  }
+
+  private static PomMinimums getPomMinimums() {
+    return PomMinimums.from(new MavenProject());
+  }
+
+  @Test
+  public void makeDataModel_ensures_sorting_is_performed() {
+    final Profile firstProfile = new Profile();
+    firstProfile.setId("b");
+    final Profile secondProfile = new Profile();
+    secondProfile.setId("a");
+    final Dependency firstProfileDependency =
+        Dependency.builder()
+            .artifactIdentifier(
+                ArtifactIdentifier.builder()
+                    .groupId("se.vandmo.dependency")
+                    .artifactId("first-profile-artifact-id")
+                    .build())
+            .version("1.0.0")
+            .integrity(Integrity.Ignored())
+            .scope("runtime")
+            .build();
+    final Dependency secondProfileDependency =
+        Dependency.builder()
+            .artifactIdentifier(
+                ArtifactIdentifier.builder()
+                    .groupId("se.vandmo.dependency")
+                    .artifactId("second-profile-artifact-id")
+                    .build())
+            .version("1.0.0")
+            .integrity(Integrity.Ignored())
+            .scope("runtime")
+            .build();
+    Map<String, Object> dataModel =
+        new WithLockFilePom()
+            .makeDataModel(
+                getPomMinimums(),
+                new ProfiledDependencies(
+                    Dependencies.fromDependencies(Collections.emptyList()),
+                    Arrays.asList(
+                        new ProfileEntry(
+                            firstProfile,
+                            Dependencies.fromDependencies(
+                                Collections.singletonList(firstProfileDependency))),
+                        new ProfileEntry(
+                            secondProfile,
+                            Dependencies.fromDependencies(
+                                Collections.singletonList(secondProfileDependency))))));
+    final Object profiles = dataModel.get("profiles");
+    Assert.assertTrue(profiles instanceof List);
+    final List<?> profilesList = (List<?>) profiles;
+    Assert.assertEquals("Unexpected number of profiles entries generated.", 2, profilesList.size());
+    Assert.assertTrue(profilesList.get(0) instanceof Map);
+    Assert.assertEquals(
+        "Unexpected ordering of profiles entries found",
+        secondProfile.getId(),
+        ((Map) profilesList.get(0)).get("id"));
+    Assert.assertTrue(profilesList.get(1) instanceof Map);
+    Assert.assertEquals(
+        "Unexpected ordering of profiles entries found",
+        firstProfile.getId(),
+        ((Map) profilesList.get(1)).get("id"));
+  }
+}


### PR DESCRIPTION
Following #114 this is removing empty profiles from lock files, to avoid unnecessary noise in projects where profiles could be defined in parent poms.

This also refactors pom lock logics to avoid code duplication.